### PR TITLE
feat(arc-591): Add enable icons option for navigation bars

### DIFF
--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -33,6 +33,9 @@ function setConfig() {
 				ContentBlockType.PageOverview,
 			],
 		},
+		navigationBars: {
+			enableIcons: false,
+		},
 		staticPages: [
 			'/admin/content',
 			'/admin/navigatie',
@@ -119,4 +122,4 @@ async function bootstrapApp() {
 	renderApp();
 }
 
-bootstrapApp().catch(err => console.error(err));
+bootstrapApp().catch((err) => console.error(err));

--- a/demo/src/react-admin/core/config/config.types.ts
+++ b/demo/src/react-admin/core/config/config.types.ts
@@ -70,6 +70,9 @@ export interface ConfigValue {
 	contentPage?: {
 		availableContentBlocks: ContentBlockType[];
 	};
+	navigationBars?: {
+		enableIcons: boolean;
+	};
 	// Secondary services and config
 	services: {
 		assetService: {

--- a/demo/src/react-admin/modules/navigation/components/NavigationEditForm/NavigationEditForm.tsx
+++ b/demo/src/react-admin/modules/navigation/components/NavigationEditForm/NavigationEditForm.tsx
@@ -26,6 +26,7 @@ interface NavigationEditFormProps {
 		value: ValueOf<NavigationItem> | PickerItem | null
 	) => void;
 	permissionWarning: ReactNode | null;
+	enableIcons: boolean;
 }
 
 const NavigationEditForm: FunctionComponent<NavigationEditFormProps> = ({
@@ -35,6 +36,7 @@ const NavigationEditForm: FunctionComponent<NavigationEditFormProps> = ({
 	navigationParentOptions,
 	onChange,
 	permissionWarning,
+	enableIcons,
 }) => {
 	const { t } = useTranslation();
 
@@ -78,15 +80,18 @@ const NavigationEditForm: FunctionComponent<NavigationEditFormProps> = ({
 					/>
 				</FormGroup>
 			)}
-			<FormGroup label={t('admin/menu/components/menu-edit-form/menu-edit-form___icoon')}>
-				<IconPicker
-					options={GET_ADMIN_ICON_OPTIONS()}
-					onChange={(option: any) => onChange('icon_name', get(option, 'value', ''))}
-					value={GET_ADMIN_ICON_OPTIONS().find(
-						(option: ReactSelectOption<string>) => option.value === formState.icon_name
-					)}
-				/>
-			</FormGroup>
+			{enableIcons && (
+				<FormGroup label={t('admin/menu/components/menu-edit-form/menu-edit-form___icoon')}>
+					<IconPicker
+						options={GET_ADMIN_ICON_OPTIONS()}
+						onChange={(option: any) => onChange('icon_name', get(option, 'value', ''))}
+						value={GET_ADMIN_ICON_OPTIONS().find(
+							(option: ReactSelectOption<string>) =>
+								option.value === formState.icon_name
+						)}
+					/>
+				</FormGroup>
+			)}
 			<FormGroup
 				error={formErrors.label}
 				label={t('admin/menu/components/menu-edit-form/menu-edit-form___label')}

--- a/demo/src/react-admin/modules/navigation/views/NavigationEdit.tsx
+++ b/demo/src/react-admin/modules/navigation/views/NavigationEdit.tsx
@@ -82,7 +82,9 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 		if (!isLoadingNavigationItems && !isErrorNavigationItems && !navigationItems?.length) {
 			// Go back to overview if no menu items are present
 			Config.getConfig().services.toastService.showToast({
-				title: Config.getConfig().services.i18n.t('modules/navigation/views/navigation-edit___error'),
+				title: Config.getConfig().services.i18n.t(
+					'modules/navigation/views/navigation-edit___error'
+				),
 				description: Config.getConfig().services.i18n.t(
 					'admin/menu/views/menu-edit___er-werden-geen-navigatie-items-gevonden-voor-menu-name',
 					{
@@ -183,7 +185,9 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 						})
 					);
 					Config.getConfig().services.toastService.showToast({
-						title: Config.getConfig().services.i18n.t('modules/navigation/views/navigation-edit___error'),
+						title: Config.getConfig().services.i18n.t(
+							'modules/navigation/views/navigation-edit___error'
+						),
 						description: Config.getConfig().services.i18n.t(
 							'admin/menu/views/menu-edit___het-controleren-of-de-permissies-van-de-pagina-overeenkomen-met-de-zichtbaarheid-van-dit-navigatie-item-is-mislukt'
 						),
@@ -240,8 +244,12 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 		try {
 			if (!navigationItems) {
 				Config.getConfig().services.toastService.showToast({
-					title: Config.getConfig().services.i18n.t('modules/navigation/views/navigation-edit___error'),
-					description: Config.getConfig().services.i18n.t('modules/navigation/views/navigation-edit___er-zijn-geen-navigatie-items-om-op-te-slaan'),
+					title: Config.getConfig().services.i18n.t(
+						'modules/navigation/views/navigation-edit___error'
+					),
+					description: Config.getConfig().services.i18n.t(
+						'modules/navigation/views/navigation-edit___er-zijn-geen-navigatie-items-om-op-te-slaan'
+					),
 					type: ToastType.ERROR,
 				});
 				return;
@@ -284,7 +292,9 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 					navigationBarId: navigationItem.placement as string,
 				});
 				Config.getConfig().services.toastService.showToast({
-					title: Config.getConfig().services.i18n.t('modules/navigation/views/navigation-edit___success'),
+					title: Config.getConfig().services.i18n.t(
+						'modules/navigation/views/navigation-edit___success'
+					),
 					description: Config.getConfig().services.i18n.t(
 						'admin/menu/views/menu-edit___het-navigatie-item-is-succesvol-aangemaakt'
 					),
@@ -308,7 +318,9 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 					navigationBarId: navigationItem.placement as string,
 				});
 				Config.getConfig().services.toastService.showToast({
-					title: Config.getConfig().services.i18n.t('modules/navigation/views/navigation-edit___success'),
+					title: Config.getConfig().services.i18n.t(
+						'modules/navigation/views/navigation-edit___success'
+					),
 					description: Config.getConfig().services.i18n.t(
 						'admin/menu/views/menu-edit___het-navigatie-item-is-succesvol-geupdatet'
 					),
@@ -322,7 +334,9 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 				})
 			);
 			Config.getConfig().services.toastService.showToast({
-				title: Config.getConfig().services.i18n.t('modules/navigation/views/navigation-edit___error'),
+				title: Config.getConfig().services.i18n.t(
+					'modules/navigation/views/navigation-edit___error'
+				),
 				description: Config.getConfig().services.i18n.t(
 					'admin/menu/views/menu-edit___het-updaten-van-het-navigatie-item-is-mislukt'
 				),
@@ -390,6 +404,7 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 						navigationParentOptions={navigationParentOptions}
 						onChange={handleChange}
 						permissionWarning={permissionWarning}
+						enableIcons={Config.getConfig().navigationBars?.enableIcons ?? true}
 					/>
 				</AdminLayout.Content>
 			</AdminLayout>


### PR DESCRIPTION
So we can hide the icon selection for hetarchief
![image](https://user-images.githubusercontent.com/1710840/172332904-8b5b6079-da6c-46cf-ae6c-7a4bb0d4be3c.png)
