### PR TITLE
feat: only update the formstate for existing items

### DIFF
--- a/ui/src/react-admin/modules/navigation/views/NavigationEdit.tsx
+++ b/ui/src/react-admin/modules/navigation/views/NavigationEdit.tsx
@@ -62,10 +62,10 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 	} = useGetNavigationItem(navigationItemId);
 
 	useEffect(() => {
-		if (initialNavigationItem) {
+		if (initialNavigationItem && navigationBarId) {
 			setNavigationItem(initialNavigationItem);
 		}
-	}, [initialNavigationItem]);
+	}, [initialNavigationItem, navigationBarId]);
 
 	useEffect(() => {
 		if (!isLoadingNavigationItems && !isErrorNavigationItems && !navigationItems?.length) {


### PR DESCRIPTION
This PR fixes the filled in formstate when creating a new navigation item after editing an existing one. Check out the video's to see the difference.


[Bugged flow - before the fix](https://user-images.githubusercontent.com/77958553/213181817-f55c530d-5f32-4c0e-9aaa-c7f970e08d7d.mov)
[Desired behaviour - after the fix](https://user-images.githubusercontent.com/77958553/213181840-8f648646-32cf-4205-96e3-b0ef0a7502ac.mov)