### PR TITLE
feat(IconPicker): render icons using the configured icon component

### DIFF
--- a/ui/src/react-admin/modules/shared/components/IconPicker/IconPicker.tsx
+++ b/ui/src/react-admin/modules/shared/components/IconPicker/IconPicker.tsx
@@ -1,7 +1,8 @@
-import { Flex, Icon, IconName, Spacer } from '@viaa/avo2-components';
+import { Flex, Spacer } from '@viaa/avo2-components';
 import clsx from 'clsx';
-import React, { FunctionComponent } from 'react';
+import { FunctionComponent } from 'react';
 import Select, { Props as ReactSelectProps } from 'react-select';
+import { AdminConfigManager } from '~core/config';
 
 import './IconPicker.scss';
 
@@ -13,9 +14,11 @@ export const IconPicker: FunctionComponent<ReactSelectProps> = ({
 	placeholder = '',
 	...rest
 }) => {
+	const Icon = AdminConfigManager.getConfig().icon?.component;
+
 	const renderLabel = (option: any) => (
 		<Flex>
-			<Icon name={option?.value as IconName} />
+			{Icon && <Icon name={option?.value} />}
 			<Spacer margin="left">{option?.label as string}</Spacer>
 		</Flex>
 	);


### PR DESCRIPTION
This PR is related to https://github.com/viaacode/hetarchief-client/pull/613.

Make sure to use the configured icon component for the iconpicker component. 
This functionality is needed to be able to render all configured icons correctly. 