### PR TITLE
fix(avo-2375): add back buttons to users, content pages, navigations

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -92,6 +92,7 @@ function setConfig() {
 				arrowUp: { name: 'arrow-up' },
 				sortTable: { name: 'sort-table' },
 				arrowDown: { name: 'arrow-down' },
+				chevronLeft: { name: 'chevron-left' },
 			},
 			list: () => [
 				{

--- a/ui/src/react-admin/core/config/config.types.ts
+++ b/ui/src/react-admin/core/config/config.types.ts
@@ -170,6 +170,7 @@ export interface IconConfig {
 		arrowUp: IconComponentProps;
 		sortTable: IconComponentProps;
 		arrowDown: IconComponentProps;
+		chevronLeft: IconComponentProps;
 	};
 	list: () => { label: string; value: string }[];
 }

--- a/ui/src/react-admin/modules/content-page/views/ContentPageDetail.tsx
+++ b/ui/src/react-admin/modules/content-page/views/ContentPageDetail.tsx
@@ -1,13 +1,5 @@
 import { get, noop } from 'lodash-es';
-import React, {
-	FC,
-	ReactElement,
-	ReactNode,
-	ReactText,
-	useCallback,
-	useEffect,
-	useState,
-} from 'react';
+import React, { FC, ReactElement, ReactText, useCallback, useEffect, useState } from 'react';
 import {
 	Blankslate,
 	Button,
@@ -19,6 +11,7 @@ import {
 	Tabs,
 } from '@viaa/avo2-components';
 import { PermissionName } from '@viaa/avo2-types';
+import { Link } from 'react-router-dom';
 
 import { AdminConfigManager } from '~core/config';
 import { ToastType } from '~core/config/config.types';
@@ -30,6 +23,7 @@ import { useSoftDeleteContentPage } from '~modules/content-page/hooks/useSoftDel
 import { ContentPageService } from '~modules/content-page/services/content-page.service';
 import { ContentPageInfo } from '~modules/content-page/types/content-pages.types';
 import { ContentPageDetailMetaData } from '~modules/content-page/views/ContentPageDetailMetaData';
+import { Icon } from '~shared/components';
 import ConfirmModal from '~shared/components/ConfirmModal/ConfirmModal';
 import {
 	LoadingErrorLoadedComponent,
@@ -59,15 +53,9 @@ const {
 export type ContentPageDetailProps = DefaultComponentProps & {
 	id: string;
 	loaded?: (item: ContentPageInfo) => void;
-	renderBack?: () => ReactNode;
 };
 
-const ContentPageDetail: FC<ContentPageDetailProps> = ({
-	id,
-	loaded = noop,
-	renderBack,
-	className,
-}) => {
+const ContentPageDetail: FC<ContentPageDetailProps> = ({ id, loaded = noop, className }) => {
 	// Hooks
 	const { tHtml, tText } = useTranslation();
 	const history = AdminConfigManager.getConfig().services.router.useHistory();
@@ -427,7 +415,13 @@ const ContentPageDetail: FC<ContentPageDetailProps> = ({
 	// const description = contentPageInfo ? ContentPageService.getDescription(contentPageInfo) : '';
 	return (
 		<AdminLayout className={className} pageTitle={pageTitle}>
-			<AdminLayout.Back>{renderBack?.()}</AdminLayout.Back>
+			<AdminLayout.Back>
+				<Link to={AdminConfigManager.getAdminRoute('CONTENT_PAGE_OVERVIEW')}>
+					<Button type="borderless">
+						<Icon name="chevronLeft"></Icon>
+					</Button>
+				</Link>
+			</AdminLayout.Back>
 			<AdminLayout.Actions>{renderContentActions()}</AdminLayout.Actions>
 			<AdminLayout.Content>
 				<Navbar background="alt" placement="top" autoHeight>

--- a/ui/src/react-admin/modules/content-page/views/ContentPageEdit.tsx
+++ b/ui/src/react-admin/modules/content-page/views/ContentPageEdit.tsx
@@ -32,6 +32,7 @@ import {
 	ContentPageInfo,
 	PageType,
 } from '~modules/content-page/types/content-pages.types';
+import { Icon } from '~shared/components';
 import ConfirmModal from '~shared/components/ConfirmModal/ConfirmModal';
 import {
 	LoadingErrorLoadedComponent,
@@ -54,10 +55,9 @@ const { EDIT_ANY_CONTENT_PAGES, EDIT_OWN_CONTENT_PAGES } = PermissionName;
 
 export type ContentPageEditProps = DefaultComponentProps & {
 	id: string | undefined;
-	renderBack?: () => ReactNode;
 };
 
-const ContentPageEdit: FC<ContentPageEditProps> = ({ id, className, renderBack }) => {
+const ContentPageEdit: FC<ContentPageEditProps> = ({ id, className }) => {
 	// Hooks
 	const [contentPageState, changeContentPageState] = useReducer<
 		Reducer<ContentPageEditState, ContentEditAction>
@@ -577,10 +577,16 @@ const ContentPageEdit: FC<ContentPageEditProps> = ({ id, className, renderBack }
 			user?.profileId && contentPageOwnerId && user?.profileId === contentPageOwnerId;
 		const isAllowedToSave =
 			hasPerm(EDIT_ANY_CONTENT_PAGES) || (hasPerm(EDIT_OWN_CONTENT_PAGES) && isOwner);
-
+		const Link = AdminConfigManager.getConfig().services.router.Link;
 		return (
 			<AdminLayout className={className} pageTitle={pageTitle}>
-				<AdminLayout.Back>{renderBack?.()}</AdminLayout.Back>
+				<AdminLayout.Back>
+					<Link to={AdminConfigManager.getAdminRoute('CONTENT_PAGE_OVERVIEW')}>
+						<Button type="borderless">
+							<Icon name="chevronLeft"></Icon>
+						</Button>
+					</Link>
+				</AdminLayout.Back>
 				<AdminLayout.Actions>
 					<ButtonToolbar>
 						<Button

--- a/ui/src/react-admin/modules/navigation/views/NavigationDetail.tsx
+++ b/ui/src/react-admin/modules/navigation/views/NavigationDetail.tsx
@@ -19,7 +19,7 @@ import { ToastType } from '~core/config/config.types';
 import { navigate } from '~shared/helpers/link';
 import { CustomError } from '~shared/helpers/custom-error';
 import { AdminLayout } from '~shared/layouts';
-import { Loader } from '~shared/components';
+import { Icon, Loader } from '~shared/components';
 import { NavigationItem } from '../navigation.types';
 import { useGetNavigationBarItems } from '~modules/navigation/hooks/use-get-navigation-bar-items';
 import { reindexNavigationItems } from '~modules/navigation/helpers/reorder-navigation-items';
@@ -300,6 +300,7 @@ const NavigationDetail: FC<NavigationDetailProps> = ({ navigationBarId }) => {
 				</p>
 			);
 		}
+		const Link = AdminConfigManager.getConfig().services.router.Link;
 		return (
 			<AdminLayout
 				pageTitle={
@@ -308,6 +309,13 @@ const NavigationDetail: FC<NavigationDetailProps> = ({ navigationBarId }) => {
 					startCase(navigationBarId)
 				}
 			>
+				<AdminLayout.Back>
+					<Link to={AdminConfigManager.getAdminRoute('NAVIGATION_OVERVIEW')}>
+						<Button type="borderless">
+							<Icon name="chevronLeft"></Icon>
+						</Button>
+					</Link>
+				</AdminLayout.Back>
 				<AdminLayout.Actions>
 					<ButtonToolbar>
 						<Button

--- a/ui/src/react-admin/modules/navigation/views/NavigationEdit.tsx
+++ b/ui/src/react-admin/modules/navigation/views/NavigationEdit.tsx
@@ -1,8 +1,9 @@
 import { compact, get, isNil, startCase, uniq, uniqBy, without } from 'lodash-es';
-import { FC, ReactNode, useCallback, useEffect, useState } from 'react';
+import React, { FC, ReactNode, useCallback, useEffect, useState } from 'react';
 
 import { Badge, Button, ButtonToolbar, Flex, Spacer, TagInfo } from '@viaa/avo2-components';
 import { ContentPageService } from '~modules/content-page/services/content-page.service';
+import { Icon } from '~shared/components';
 import { CenteredSpinner } from '~shared/components/Spinner/CenteredSpinner';
 import { UserGroup } from '~modules/user-group/types/user-group.types';
 
@@ -359,8 +360,16 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 					GET_PAGE_TYPES_LANG()[pageType]
 			  }`
 			: tText('admin/menu/views/menu-edit___navigatie-toevoegen');
+		const Link = AdminConfigManager.getConfig().services.router.Link;
 		return (
 			<AdminLayout pageTitle={pageTitle}>
+				<AdminLayout.Back>
+					<Link to={AdminConfigManager.getAdminRoute('NAVIGATION_OVERVIEW')}>
+						<Button type="borderless">
+							<Icon name="chevronLeft"></Icon>
+						</Button>
+					</Link>
+				</AdminLayout.Back>
 				<AdminLayout.Actions>
 					<ButtonToolbar>
 						<Button

--- a/ui/src/react-admin/modules/user/views/UserDetail.tsx
+++ b/ui/src/react-admin/modules/user/views/UserDetail.tsx
@@ -12,6 +12,7 @@ import {
 import { PermissionName } from '@viaa/avo2-types';
 import type { Avo } from '@viaa/avo2-types';
 import React, { FC, ReactText, useCallback, useEffect, useState } from 'react';
+import { Icon } from '~shared/components';
 import { ErrorView } from '~shared/components/error';
 import { CenteredSpinner } from '~shared/components/Spinner/CenteredSpinner';
 import { useGetProfileById } from '~modules/user/use-get-profile-by-id';
@@ -400,6 +401,7 @@ export const UserDetail: FC<UserDetailProps> = ({ id, onSetTempAccess, onLoaded 
 		navigate(history, AdminConfigManager.getAdminRoute('USER_OVERVIEW'));
 
 	const renderUserDetailPage = () => {
+		const Link = AdminConfigManager.getConfig().services.router.Link;
 		const isBlocked = storedProfile?.isBlocked;
 		const blockButtonTooltip = isBlocked
 			? tText(
@@ -409,6 +411,13 @@ export const UserDetail: FC<UserDetailProps> = ({ id, onSetTempAccess, onLoaded 
 		return (
 			<>
 				<AdminLayout pageTitle={tText('admin/users/views/user-detail___gebruiker-details')}>
+					<AdminLayout.Back>
+						<Link to={AdminConfigManager.getAdminRoute('USER_OVERVIEW')}>
+							<Button type="borderless">
+								<Icon name="chevronLeft"></Icon>
+							</Button>
+						</Link>
+					</AdminLayout.Back>
 					<AdminLayout.Actions>
 						<ButtonToolbar>
 							{canBanUser() && (

--- a/ui/src/react-admin/modules/user/views/UserEdit.tsx
+++ b/ui/src/react-admin/modules/user/views/UserEdit.tsx
@@ -16,6 +16,7 @@ import {
 import type { Avo } from '@viaa/avo2-types';
 import { compact, get } from 'lodash-es';
 import React, { FC, useCallback, useEffect, useState } from 'react';
+import { Icon } from '~shared/components';
 import { AdminLayout } from '../../shared/layouts';
 import { UserService } from '../user.service';
 
@@ -295,8 +296,16 @@ export const UserEdit: FC<UserEditProps> = ({ id, onSave, onLoaded }) => {
 	};
 
 	const renderUserDetailPage = () => {
+		const Link = AdminConfigManager.getConfig().services.router.Link;
 		return (
 			<AdminLayout pageTitle={tText('admin/users/views/user-edit___bewerk-gebruiker')}>
+				<AdminLayout.Back>
+					<Link to={AdminConfigManager.getAdminRoute('USER_OVERVIEW')}>
+						<Button type="borderless">
+							<Icon name="chevronLeft"></Icon>
+						</Button>
+					</Link>
+				</AdminLayout.Back>
 				<AdminLayout.Actions>
 					<ButtonToolbar>
 						<Button


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2375

page:
* http://localhost:8080/admin/gebruikers/a900a663-c319-4b3c-99da-ede663ad29fc
* http://localhost:8080/admin/gebruikers/a900a663-c319-4b3c-99da-ede663ad29fc/bewerk
* http://localhost:8080/admin/content/1529
* http://localhost:8080/admin/content/1529/bewerk
* http://localhost:8080/admin/navigatie/footer-links
* http://localhost:8080/admin/navigatie/footer-links/1/bewerk

before:
![image](https://user-images.githubusercontent.com/1710840/216096564-de3f786e-ff0d-44e3-b4e9-b0ebcf92a6d9.png)

after:
![image](https://user-images.githubusercontent.com/1710840/216096537-aeae8fec-e2dc-4038-a7b4-2115b9208d0a.png)
