### PR TITLE
fix(avo-2416): delete id before trying to duplicate a content page

### DIFF
--- a/api/src/modules/content-pages/services/content-pages.service.ts
+++ b/api/src/modules/content-pages/services/content-pages.service.ts
@@ -387,7 +387,6 @@ export class ContentPagesService {
 				return null;
 			}
 
-			console.log('user: ', user);
 			// Check if content page is accessible for the user who requested the content page
 			if (
 				!intersection(

--- a/api/src/modules/content-pages/services/content-pages.service.ts
+++ b/api/src/modules/content-pages/services/content-pages.service.ts
@@ -909,6 +909,7 @@ export class ContentPagesService {
 	): Promise<DbContentPage | null> {
 		try {
 			const dbContentPage = this.convertToDatabaseContentPage(contentPage);
+			delete dbContentPage.id; // No id needed for new content pages (or duplicates of existing ones
 			const response = await this.dataService.execute<
 				ContentPageQueryTypes['InsertContentMutation'],
 				ContentPageQueryTypes['InsertContentMutationVariables']
@@ -923,29 +924,31 @@ export class ContentPagesService {
 					.insert_app_content_page?.returning?.[0]?.id ||
 				null;
 
-			if (id) {
-				// Insert content-blocks
-				let contentBlockConfigs: Partial<DbContentBlock>[] | null = null;
-				if (contentPage.content_blocks && contentPage.content_blocks.length) {
-					contentBlockConfigs = await this.insertContentBlocks(
-						id,
-						contentPage.content_blocks,
-					);
-
-					if (!contentBlockConfigs) {
-						// return null to prevent triggering success toast
-						return null;
-					}
-				}
-
-				return {
-					...contentPage,
-					content_blocks: contentBlockConfigs,
-					id,
-				} as DbContentPage;
+			if (!id) {
+				throw new InternalServerErrorException(
+					CustomError(
+						'Failed to insert content page, received no id from the database',
+						null,
+						{ response },
+					),
+				);
 			}
 
-			return null;
+			// Insert content-blocks
+			let contentBlockConfigs: Partial<DbContentBlock>[] | null = null;
+			if (contentPage.content_blocks && contentPage.content_blocks.length) {
+				contentBlockConfigs = await this.insertContentBlocks(
+					id,
+					contentPage.content_blocks,
+				);
+
+				if (!contentBlockConfigs) {
+					// return null to prevent triggering success toast
+					return null;
+				}
+			}
+
+			return this.getContentPageById(String(id));
 		} catch (err) {
 			console.error('Failed to insert content page into the database', err);
 			return null;

--- a/api/src/modules/content-pages/services/content-pages.service.ts
+++ b/api/src/modules/content-pages/services/content-pages.service.ts
@@ -1082,7 +1082,6 @@ export class ContentPagesService {
 			return {
 				content_block_type: block.type as Lookup_Enum_Content_Block_Types_Enum,
 				content_id: block.content_id,
-				id: block.id,
 				position: block.position,
 				variables: {
 					blockState: block.block,

--- a/ui/src/react-admin/modules/content-page/services/content-page.service.ts
+++ b/ui/src/react-admin/modules/content-page/services/content-page.service.ts
@@ -85,7 +85,7 @@ export class ContentPageService {
 			stringifyUrl({
 				url: `${this.getBaseUrl()}/public`,
 				query: {
-					limit,
+					limit: limit ?? 20,
 					title,
 				},
 			}),

--- a/ui/src/react-admin/modules/content-page/views/ContentPageOverview.tsx
+++ b/ui/src/react-admin/modules/content-page/views/ContentPageOverview.tsx
@@ -227,7 +227,11 @@ const ContentPageOverview: FunctionComponent = () => {
 		return { _and: andFilters };
 	};
 
-	const { data: contentPageResponse, isLoading } = useGetContentPagesOverview({
+	const {
+		data: contentPageResponse,
+		isLoading,
+		refetch: refetchContentPages,
+	} = useGetContentPagesOverview({
 		page: tableState.page || 0,
 		sortColumn: (tableState.sort_column as ContentOverviewTableCols) || 'updated_at',
 		sortOrder: tableState.sort_order || 'desc',
@@ -254,8 +258,7 @@ const ContentPageOverview: FunctionComponent = () => {
 			}
 
 			await ContentPageService.deleteContentPage(contentToDelete.id);
-			const queryClient = new QueryClient();
-			await queryClient.invalidateQueries([QUERY_KEYS.GET_CONTENT_PAGE_OVERVIEW]);
+			await refetchContentPages();
 			AdminConfigManager.getConfig().services.toastService.showToast({
 				title: tText(
 					'modules/admin/content-page/pages/content-page-overview/content-page-overview___success'

--- a/ui/src/react-admin/modules/shared/components/ContentPicker/item-providers/content-page.ts
+++ b/ui/src/react-admin/modules/shared/components/ContentPicker/item-providers/content-page.ts
@@ -1,5 +1,5 @@
-import { CustomError } from '../../../helpers/custom-error';
-import { PickerItem } from '../../../types/content-picker';
+import { CustomError } from '~shared/helpers/custom-error';
+import { PickerItem } from '~shared/types/content-picker';
 import { parsePickerItem } from '../helpers/parse-picker';
 
 import { ContentPageService } from '~modules/content-page/services/content-page.service';


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2416

page:
* http://localhost:3400/admin/content
* http://localhost:3400/admin/content/1585

## fixed delete content page => should remove content page from overview

before:
![image](https://user-images.githubusercontent.com/1710840/217274748-f2e3c95b-393d-4d9b-a2ef-795e885df569.png)
![image](https://user-images.githubusercontent.com/1710840/217274778-4677b26b-419c-4bb2-83fa-f0737d0981b6.png)

after:
![image](https://user-images.githubusercontent.com/1710840/217274883-a2d071e3-e47d-46dc-86eb-50b0353bb547.png)
![image](https://user-images.githubusercontent.com/1710840/217274906-cc2a8b7a-e685-46fb-a685-88ac9822dfaa.png)

## fixed duplicate content page => should duplicate content page without any errors

before:
![image](https://user-images.githubusercontent.com/1710840/217274965-5a0759e8-1949-41e2-accc-2d5bd5bd34e5.png)
![image](https://user-images.githubusercontent.com/1710840/217274984-52de93ef-4726-4513-b049-73260bdc0309.png)

after:
![image](https://user-images.githubusercontent.com/1710840/217275118-fd4944c9-c48a-4fe2-86e1-2b00d19d9a69.png)
![image](https://user-images.githubusercontent.com/1710840/217275040-95355cf6-8423-4d17-bb2d-66a478ff1125.png)
