### PR TITLE
fix(avo-2410): fix loading contentPage description into rich text editor

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/ContentEditForm/ContentEditForm.tsx
+++ b/ui/src/react-admin/modules/content-page/components/ContentEditForm/ContentEditForm.tsx
@@ -68,7 +68,7 @@ export const ContentEditForm: FunctionComponent<ContentEditFormProps> = ({
 
 	const changeContentPageProp = useCallback(
 		(
-			propName: keyof ContentPageInfo | 'description_state' | 'description_html',
+			propName: keyof ContentPageInfo | 'description_state',
 			propValue: ValueOf<ContentPageInfo> | RichEditorState | string
 		) =>
 			changeContentPageState({
@@ -202,15 +202,13 @@ export const ContentEditForm: FunctionComponent<ContentEditFormProps> = ({
 							</Column>
 							<Column size="12">
 								<FormGroup
-									error={formErrors.description_html}
+									error={formErrors.description}
 									label={tText(
 										'admin/content/components/content-edit-form/content-edit-form___omschrijving'
 									)}
 								>
 									<RichTextEditorWrapper
-										initialHtml={
-											(contentPageInfo as any).description_html || ''
-										}
+										initialHtml={(contentPageInfo as any).description || ''}
 										state={
 											(contentPageInfo as any).description_state || undefined
 										}

--- a/ui/src/react-admin/modules/content-page/helpers/content-edit.reducer.ts
+++ b/ui/src/react-admin/modules/content-page/helpers/content-edit.reducer.ts
@@ -29,7 +29,7 @@ interface SetContentPage {
 interface SetContentPageProp {
 	type: ContentEditActionType.SET_CONTENT_PAGE_PROP;
 	payload: {
-		propName: keyof ContentPageInfo | 'description_state' | 'description_html';
+		propName: keyof ContentPageInfo | 'description_state';
 		propValue: ValueOf<ContentPageInfo> | RichEditorState | string;
 	};
 }

--- a/ui/src/react-admin/modules/content-page/types/content-pages.types.ts
+++ b/ui/src/react-admin/modules/content-page/types/content-pages.types.ts
@@ -110,7 +110,7 @@ export interface ContentPageUser {
 }
 
 export type ContentEditFormErrors = Partial<{ [key in keyof ContentPageInfo]: string }> & {
-	description_html?: string;
+	description?: string;
 };
 
 export enum ContentEditActionType {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2410

page: http://localhost:3400/admin/content/1586/bewerk

before:
when entering a description for a content page
saving
and again editing the content page, the description rich text editor would be empty.


after:
![image](https://user-images.githubusercontent.com/1710840/218070556-1c47c877-28b2-48f5-be81-9b6562291546.png)
![image](https://user-images.githubusercontent.com/1710840/218070570-12cbf9c1-6fda-47b7-a418-172d5a9c7f85.png)
![image](https://user-images.githubusercontent.com/1710840/218070583-6669c7ff-2c29-42de-bb48-107865c54be6.png)
