### PR TITLE
feat(arc-1448): add content block class for each content block type

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/ContentBlockRenderer/ContentBlockRenderer.tsx
+++ b/ui/src/react-admin/modules/content-page/components/ContentBlockRenderer/ContentBlockRenderer.tsx
@@ -35,8 +35,8 @@ const ContentBlockRenderer: FunctionComponent<ContentBlockPreviewProps> = ({
 	onClick = noop,
 	className,
 }) => {
-	const blockState = get(contentBlockConfig, 'block.state');
-	const componentState = get(contentBlockConfig, 'components.state');
+	const blockState = contentBlockConfig?.block?.state;
+	const componentState = contentBlockConfig?.components?.state;
 	const containerSize =
 		contentPageInfo.contentWidth?.toUpperCase() ||
 		AdminConfigManager.getConfig().contentPage?.defaultPageWidth ||
@@ -126,13 +126,10 @@ const ContentBlockRenderer: FunctionComponent<ContentBlockPreviewProps> = ({
 					'c-content-block-preview--dark': hasDarkBg,
 					'u-color-white': hasDarkBg,
 				})}
-				margin={[
-					get(blockState, 'margin.top', 'none'),
-					get(blockState, 'margin.bottom', 'none'),
-				]}
+				margin={[blockState?.margin?.top ?? 'none', blockState?.margin?.bottom ?? 'none']}
 				padding={[
-					get(blockState, 'padding.top', 'none'),
-					get(blockState, 'padding.bottom', 'none'),
+					blockState?.padding?.top ?? 'none',
+					blockState?.padding?.bottom ?? 'none',
 				]}
 			>
 				<div

--- a/ui/src/react-admin/modules/content-page/components/ContentBlockRenderer/ContentBlockRenderer.tsx
+++ b/ui/src/react-admin/modules/content-page/components/ContentBlockRenderer/ContentBlockRenderer.tsx
@@ -1,6 +1,6 @@
 import { Container, Spacer } from '@viaa/avo2-components';
 import clsx from 'clsx';
-import { get, noop, omit } from 'lodash-es';
+import { kebabCase, noop, omit } from 'lodash-es';
 import React, { FunctionComponent, RefObject, useCallback, useEffect, useRef } from 'react';
 import { generateSmartLink } from '~shared/components/SmartLink/SmartLink';
 
@@ -107,7 +107,11 @@ const ContentBlockRenderer: FunctionComponent<ContentBlockPreviewProps> = ({
 
 	return (
 		<div
-			className={clsx('c-content-block', className)}
+			className={clsx(
+				'c-content-block',
+				className,
+				'c-content-block__' + kebabCase(contentBlockConfig.type)
+			)}
 			style={{
 				backgroundColor: blockState.backgroundColor,
 				...(blockState.headerBackgroundColor !== Color.Transparent ? { zIndex: 1 } : {}),


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1448

For some of the content blocks we want to be able to add specific styling. This PR adds a class to each content block based on its type which will make styling easier:
![image](https://user-images.githubusercontent.com/1710840/223176245-505d6c90-7e59-4c36-8b15-1dce5a6c2fab.png)

