### PR TITLE
AVO-2453 Allow not found content pages in spotlight block

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockSpotlight/BlockProjectSpotlight.wrapper.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockSpotlight/BlockProjectSpotlight.wrapper.tsx
@@ -1,6 +1,6 @@
 import { ButtonAction, RenderLinkFunction } from '@viaa/avo2-components';
-import { get } from 'lodash-es';
 import React, { FunctionComponent, useCallback, useEffect, useState } from 'react';
+import { AdminConfigManager } from '~core/config';
 
 import { ContentPageService } from '../../../services/content-page.service';
 
@@ -38,7 +38,7 @@ export const BlockProjectSpotlightWrapper: FunctionComponent<ProjectSpotlightWra
 	const fetchContentPages = useCallback(async () => {
 		try {
 			const promises = elements.map((projectInfo: ProjectSpotlightProps) => {
-				const projectPath = get(projectInfo, 'project.value');
+				const projectPath = projectInfo?.project?.value;
 				if (projectPath && projectPath.toString && projectPath.toString()) {
 					return ContentPageService.getContentPageByPath(
 						projectInfo.project.value.toString()
@@ -77,17 +77,26 @@ export const BlockProjectSpotlightWrapper: FunctionComponent<ProjectSpotlightWra
 			<BlockSpotlight
 				elements={projectContentPages.map(
 					(projectContentPage: ContentPageInfo | null, index: number): ImageInfo => {
-						return {
-							title:
-								elements[index].customTitle ||
-								get(projectContentPage, 'title') ||
-								'',
-							image:
-								elements[index].customImage ||
-								get(projectContentPage, 'thumbnail_path') ||
-								'',
-							buttonAction: elements[index].project,
-						};
+						const element = elements[index];
+						if (projectContentPage) {
+							return {
+								title: element?.customTitle || projectContentPage?.title || '',
+								image:
+									element?.customImage || projectContentPage?.thumbnailPath || '',
+								buttonAction: element?.project,
+							};
+						} else {
+							return {
+								title:
+									AdminConfigManager.getConfig().services.i18n.tText(
+										'Pagina niet gevonden'
+									) +
+									': ' +
+									element.project?.value?.toString(),
+								image: '',
+								buttonAction: undefined,
+							};
+						}
 					}
 				)}
 				renderLink={renderLink}

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockSpotlight/BlockSpotlight.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockSpotlight/BlockSpotlight.tsx
@@ -6,7 +6,6 @@ import {
 	RenderLinkFunction,
 } from '@viaa/avo2-components';
 import classnames from 'classnames';
-import { get } from 'lodash-es';
 import React, { FunctionComponent } from 'react';
 import { defaultRenderLinkFunction } from '~shared/helpers/link';
 
@@ -30,23 +29,24 @@ export const BlockSpotlight: FunctionComponent<BlockSpotlightProps> = ({
 	className,
 }) => {
 	function renderItem(index: number) {
-		if (!elements[index]) {
+		const element = elements?.[index];
+		if (!element) {
 			return null;
 		}
-		const buttonAction = get(elements, [index, 'buttonAction']);
+		const buttonAction = element?.buttonAction;
 		return (
 			<div
 				className={classnames('c-spotlight__item', {
 					'u-clickable': !!buttonAction,
 				})}
-				style={{ backgroundImage: `url(${get(elements, [index, 'image'])})` }}
+				style={{ backgroundImage: `url(${element?.image})` }}
 			>
 				{renderLink(
 					buttonAction,
 					<p>
-						{get(elements, [index, 'title'])} <Icon name={'chevronRight' as IconName} />
+						{element?.title} <Icon name={'chevronRight' as IconName} />
 					</p>,
-					get(elements, [index, 'title'])
+					element?.title
 				)}
 			</div>
 		);

--- a/ui/src/react-admin/modules/shared/components/FileUpload/FileUpload.tsx
+++ b/ui/src/react-admin/modules/shared/components/FileUpload/FileUpload.tsx
@@ -157,6 +157,7 @@ const FileUpload: FunctionComponent<FileUploadProps> = ({
 				),
 				type: ToastType.ERROR,
 			});
+			onChange([]);
 		}
 
 		setIsProcessing(false);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2453

example: http://localhost:3400/admin/content/1642

# issue 1
A spotlight block is a block where you can select 3 content pages to be displayed.

If one of those content pages is deleted, the whole block fails:
![image](https://user-images.githubusercontent.com/1710840/224276634-7f6a774c-10f2-45a5-a72a-5b6f86c65638.png)


This PR makes the spotlight block fault tolerant:
![image](https://user-images.githubusercontent.com/1710840/224276714-3a165253-ab3e-4f4b-a612-184523c45f84.png)

If a page is not found, it will show a message: Pagina niet gevonden, with the path to the missing page, so a meemoo admin can resolve the issue.

# issue 2

I also fixed an issue if a cover image was deleted on the server, we were not able to delete it anymore from a content page. Now if there is an issue with the delete from the server, we still allow the user to continue editing the content page by deleting the cover url to the faulty image from the content page.

Note that uploading images in the admin-core demo app is not possible, since the media upload service is part of the avo/hetarchief client app.

example page: http://localhost:3400/admin/content/1643/bewerk

![image](https://user-images.githubusercontent.com/1710840/224277431-7271ad71-7844-4c48-8e0a-cca517ca4c1a.png)

