### PR TITLE
fix(avo-2442): de-select users when an error is occurred during export

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -312,6 +312,9 @@ function setConfig() {
 			USER_OVERVIEW: `/${ROUTE_PARTS.admin}/${ROUTE_PARTS.users}`,
 			SEARCH: `/${ROUTE_PARTS.search}`,
 		},
+		users: {
+			bulkActions: ['block', 'unblock', 'delete', 'change_subjects', 'export'],
+		},
 		env: {
 			LDAP_DASHBOARD_PEOPLE_URL: 'https://google.com?q=people',
 		},

--- a/ui/src/react-admin/modules/user/views/UserOverview.tsx
+++ b/ui/src/react-admin/modules/user/views/UserOverview.tsx
@@ -350,7 +350,9 @@ export const UserOverview: FC<UserOverviewProps> = ({ customFormatDate, commonUs
 			const csvString = csvRowValues.join('\n');
 			const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8' });
 			FileSaver.saveAs(blob, 'gebruikers.csv');
+			setSelectedProfileIds([]);
 		} catch (err) {
+			setSelectedProfileIds([]);
 			console.error(
 				new CustomError('Failed to export users to csv file', err, { tableState })
 			);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2442

When someone selects all users on production and tries to export them, this is too heavy and the request fails.
But the users remain selected, so all subsequent exports fail

This PR clears the selected users list after a succesful and after a failed export to avoid this issue.

![image](https://user-images.githubusercontent.com/1710840/225648845-d346d3ce-0ae2-4f6d-b472-74895c4c7a0e.png)
