### PR TITLE
fix(arc-1483): remove the navigation bar add button

### DIFF
--- a/ui/src/react-admin/modules/navigation/hooks/use-get-navigation-bar-items.ts
+++ b/ui/src/react-admin/modules/navigation/hooks/use-get-navigation-bar-items.ts
@@ -11,6 +11,9 @@ export const useGetNavigationBarItems = (
 	return useQuery(
 		[QUERY_KEYS.GET_NAVIGATION_BAR_ITEMS],
 		async () => {
+			if (!placement) {
+				return [];
+			}
 			const navItems = await NavigationService.fetchNavigationBarItems(placement);
 			reindexNavigationItems(navItems);
 			return navItems;

--- a/ui/src/react-admin/modules/navigation/navigation.types.ts
+++ b/ui/src/react-admin/modules/navigation/navigation.types.ts
@@ -2,7 +2,10 @@ import { ContentPickerType } from '~shared/components/ContentPicker/ContentPicke
 
 export type NavigationOverviewTableCols = 'placement' | 'description' | 'actions';
 
-export type NavigationEditPageType = 'edit' | 'create';
+export enum NavigationEditPageType {
+	edit = 'edit',
+	create = 'create',
+}
 
 export interface NavigationEditFormErrorState {
 	description?: string;

--- a/ui/src/react-admin/modules/navigation/views/NavigationEdit.tsx
+++ b/ui/src/react-admin/modules/navigation/views/NavigationEdit.tsx
@@ -60,14 +60,57 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 		isError: isErrorNavigationItem,
 	} = useGetNavigationItem(navigationItemId);
 
+	// Computed
+	const pageType: NavigationEditPageType = navigationItemId
+		? NavigationEditPageType.edit
+		: NavigationEditPageType.create;
+	const navigationParentOptions = uniqBy(
+		compact(
+			(navigationItems || []).map((navigationItem) => {
+				if (!navigationItem.placement) {
+					return null;
+				}
+				return {
+					label: startCase(navigationItem.placement || ''),
+					value: navigationItem.placement,
+				};
+			})
+		),
+		'value'
+	);
+
 	useEffect(() => {
-		if (initialNavigationItem && navigationBarId && !isLoadingNavigationItem) {
-			setNavigationItem(initialNavigationItem);
+		if (navigationBarId && !isLoadingNavigationItem) {
+			if (initialNavigationItem) {
+				setNavigationItem(initialNavigationItem);
+			} else {
+				const newNavigationItem: NavigationItem = {
+					id: '',
+					description: '',
+					placement: navigationBarId,
+					tooltip: null,
+					iconName: '',
+					label: null,
+					userGroupIds: null,
+					contentType: null,
+					contentPath: null,
+					linkTarget: null,
+					position: 0,
+					createdAt: new Date().toISOString(),
+					updatedAt: new Date().toISOString(),
+				};
+				setNavigationItem(newNavigationItem);
+			}
 		}
 	}, [initialNavigationItem, navigationBarId, isLoadingNavigationItem]);
 
 	useEffect(() => {
-		if (!isLoadingNavigationItems && !isErrorNavigationItems && !navigationItems?.length) {
+		if (
+			!isLoadingNavigationItems &&
+			!isErrorNavigationItems &&
+			pageType === NavigationEditPageType.edit &&
+			!navigationItems?.length
+		) {
 			// Go back to overview if no menu items are present
 			showToast(
 				ToastType.ERROR,
@@ -87,6 +130,7 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 		isErrorNavigationItems,
 		navigationItems,
 		navigationBarName,
+		pageType,
 		history,
 		tText,
 	]);
@@ -179,23 +223,6 @@ const NavigationEdit: FC<NavigationEditProps> = ({ navigationBarId, navigationIt
 				});
 		}
 	}, [navigationItem, checkMenuItemContentPagePermissionsMismatch, tText]);
-
-	// Computed
-	const pageType: NavigationEditPageType = navigationItemId ? 'edit' : 'create';
-	const navigationParentOptions = uniqBy(
-		compact(
-			(navigationItems || []).map((navigationItem) => {
-				if (!navigationItem.placement) {
-					return null;
-				}
-				return {
-					label: startCase(navigationItem.placement || ''),
-					value: navigationItem.placement,
-				};
-			})
-		),
-		'value'
-	);
 
 	// Methods
 	const showToast = (type: ToastType, title: string, description: string): void => {

--- a/ui/src/react-admin/modules/navigation/views/NavigationOverview.tsx
+++ b/ui/src/react-admin/modules/navigation/views/NavigationOverview.tsx
@@ -111,16 +111,17 @@ const NavigationOverview: FunctionComponent = () => {
 		const title = tText('admin/menu/views/menu-overview___navigatie-overzicht');
 		return (
 			<AdminLayout pageTitle={title}>
-				<AdminLayout.Actions>
-					<ButtonToolbar>
-						<Button
-							label={tText('admin/menu/views/menu-overview___navigatie-toevoegen')}
-							onClick={() =>
-								history.push(AdminConfigManager.getAdminRoute('NAVIGATION_CREATE'))
-							}
-						/>
-					</ButtonToolbar>
-				</AdminLayout.Actions>
+				{/* TODO re-enable once we want to allow meemoo to create new navigation bars, usually this isn't needed, since new navigation bars always require new development work */}
+				{/*<AdminLayout.Actions>*/}
+				{/*	<ButtonToolbar>*/}
+				{/*		<Button*/}
+				{/*			label={tText('admin/menu/views/menu-overview___navigatie-toevoegen')}*/}
+				{/*			onClick={() =>*/}
+				{/*				history.push(AdminConfigManager.getAdminRoute('NAVIGATION_CREATE'))*/}
+				{/*			}*/}
+				{/*		/>*/}
+				{/*	</ButtonToolbar>*/}
+				{/*</AdminLayout.Actions>*/}
 				<AdminLayout.Content>
 					<Table
 						columns={columns}

--- a/ui/src/shared/translations/hetArchief/nl.json
+++ b/ui/src/shared/translations/hetArchief/nl.json
@@ -465,7 +465,7 @@
   "admin/menu/views/menu-detail___verwijder-dit-navigatie-item": "Verwijder dit navigatie item",
   "admin/menu/views/menu-detail___voeg-een-item-toe": "Voeg een item toe",
   "admin/menu/views/menu-edit___de-geselecteerde-pagina-is-niet-toegankelijk-voor": "De geselecteerde pagina is niet toegankelijk voor",
-  "admin/menu/views/menu-edit___er-werden-geen-navigatie-items-gevonden-voor-menu-name": "Er werden geen navigatie items gevonden voor menu name",
+  "admin/menu/views/menu-edit___er-werden-geen-navigatie-items-gevonden-voor-menu-name": "Er werden geen navigatie items gevonden voor {{menuName}}",
   "admin/menu/views/menu-edit___het-controleren-of-de-permissies-van-de-pagina-overeenkomen-met-de-zichtbaarheid-van-dit-navigatie-item-is-mislukt": "Het controleren of de permissies van de pagina overeenkomen met de zichtbaarheid van dit navigatie item is mislukt",
   "admin/menu/views/menu-edit___het-navigatie-item-is-succesvol-aangemaakt": "Het navigatie item is succesvol aangemaakt",
   "admin/menu/views/menu-edit___het-navigatie-item-is-succesvol-geupdatet": "Het navigatie item is succesvol geupdatet",


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1483

We don't want to allow meemoo to add navigation bars, only items on existing navigation bars.
Since adding a navigation bar requires dev changes in the frontend

before:
![image](https://user-images.githubusercontent.com/1710840/228251539-8b1b2ea1-fdca-4192-a0d2-cb7509018a5f.png)

after:
![image](https://user-images.githubusercontent.com/1710840/228251561-79e4c593-73aa-4951-9f31-7b98a59ad805.png)
