### PR TITLE
fix(avo-2401): Adjust component key to prevent duplicates being rendered

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockImageGrid/BlockImageGrid.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockImageGrid/BlockImageGrid.tsx
@@ -97,7 +97,7 @@ export const BlockImageGrid: FunctionComponent<BlockImageGridProps> = ({
 		>
 			{elements.map((element, index) => (
 				<div
-					key={`block-grid-${element?.action?.value || element.title || index}`}
+					key={`block-grid-${element?.action?.value || element.title || null}${index}`}
 					className={classnames('c-block-grid__item')}
 					style={{
 						width: `${itemWidth}px`,


### PR DESCRIPTION
[AVO-2401](https://meemoo.atlassian.net/browse/AVO-2401)

Fix:
Adjust grid item component key to prevent duplicates being rendered


[AVO-2401]: https://meemoo.atlassian.net/browse/AVO-2401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ