### PR TITLE
feat(BlockThreeClickableTiles): add heading type + tweak html outline

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockThreeClickableTiles/BlockThreeClickableTiles.editorconfig.ts
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockThreeClickableTiles/BlockThreeClickableTiles.editorconfig.ts
@@ -6,6 +6,7 @@ import {
 	DefaultContentBlockState,
 	ThreeClickableTilesBlockComponentState,
 } from '../../../types/content-block.types';
+import { GET_HEADING_TYPE_OPTIONS } from '~modules/content-page/const/get-heading-type-options';
 
 import { BLOCK_FIELD_DEFAULTS, BLOCK_STATE_DEFAULTS, FILE_FIELD, TEXT_FIELD } from '../defaults';
 
@@ -15,8 +16,9 @@ import { FileUploadProps } from '~modules/shared/components/FileUpload/FileUploa
 export const INITIAL_THREE_CLICKABLE_TILES_COMPONENTS_STATE =
 	(): ThreeClickableTilesBlockComponentState[] => [
 		{
-			subtitle: '',
-			source: '',
+			title: '',
+			image: '',
+			titleType: 'h4',
 		},
 	];
 
@@ -39,7 +41,7 @@ export const THREE_CLICKABLE_TILES_BLOCK_CONFIG = (position = 0): ContentBlockCo
 		},
 		state: INITIAL_THREE_CLICKABLE_TILES_COMPONENTS_STATE(),
 		fields: {
-			imgSource: FILE_FIELD(
+			image: FILE_FIELD(
 				AdminConfigManager.getConfig().services.i18n.tText(
 					'admin/content-block/helpers/generators/three-clickable-tiles___afbeelding-is-verplicht'
 				),
@@ -50,7 +52,7 @@ export const THREE_CLICKABLE_TILES_BLOCK_CONFIG = (position = 0): ContentBlockCo
 					editorProps: { assetType: 'CONTENT_BLOCK_IMAGE' } as FileUploadProps,
 				}
 			),
-			subtitle: TEXT_FIELD(
+			title: TEXT_FIELD(
 				AdminConfigManager.getConfig().services.i18n.tText(
 					'admin/content-block/helpers/generators/three-clickable-tiles___subtitel-is-verplicht'
 				),
@@ -61,6 +63,15 @@ export const THREE_CLICKABLE_TILES_BLOCK_CONFIG = (position = 0): ContentBlockCo
 					editorType: ContentBlockEditor.TextInput,
 				}
 			),
+			titleType: {
+				label: AdminConfigManager.getConfig().services.i18n.tText(
+					'admin/content-block/helpers/generators/heading___type'
+				),
+				editorType: ContentBlockEditor.Select,
+				editorProps: {
+					options: GET_HEADING_TYPE_OPTIONS(),
+				},
+			},
 			link: {
 				label: AdminConfigManager.getConfig().services.i18n.tText(
 					'admin/content-block/helpers/generators/three-clickable-tiles___link'

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockThreeClickableTiles/BlockThreeClickableTiles.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockThreeClickableTiles/BlockThreeClickableTiles.tsx
@@ -1,14 +1,18 @@
 import { ButtonAction } from '@viaa/avo2-components';
 import classnames from 'classnames';
-import { isNil } from 'lodash-es';
+import { Image } from '@viaa/avo2-components';
 import { FunctionComponent, ReactElement, ReactNode } from 'react';
-import { Icon } from '~modules/shared/components';
-import SmartLink from '~modules/shared/components/SmartLink/SmartLink';
 import { DefaultComponentProps } from '~modules/shared/types/components';
+import { isNil } from 'lodash-es';
+import SmartLink from '~modules/shared/components/SmartLink/SmartLink';
+import { Icon } from '~modules/shared/components';
+import { HeadingTypeOption } from '~modules/content-page/types/content-block.types';
+import { BlockHeading } from '../BlockHeading';
 
 export interface BlockClickableTilesProps {
-	subtitle: string;
-	imgSource: string;
+	title: string;
+	titleType: HeadingTypeOption;
+	image: string;
 	link?: ButtonAction;
 }
 
@@ -20,49 +24,43 @@ export const BlockThreeClickableTiles: FunctionComponent<BlockThreeClickableTile
 	className,
 	elements,
 }): ReactElement => {
-	const renderTile = (
-		link: ButtonAction | undefined,
-		subtitle: string,
-		imgSource: string,
-		i: number
-	): ReactElement => {
-		const element = (
-			<div className="c-block-three-clickable-tiles__tile">
-				<div
-					className="c-block-three-clickable-tiles__tile-image"
-					style={{
-						backgroundImage: `url('${imgSource}')`,
-					}}
-				/>
-				<div className="c-block-three-clickable-tiles__tile-subtitle">
-					<h5 className="u-text-ellipsis--2">{subtitle}</h5>
+	const renderTile = ({ image, title, titleType }: BlockClickableTilesProps, i: number) => (
+		<article
+			key={`c-block-three-clickable-tiles-${i}`}
+			className="c-block-three-clickable-tiles__tile"
+		>
+			<Image src={image} alt={title} className={`c-block-three-clickable-tiles__image`} />
+			<div className="c-block-three-clickable-tiles__content">
+				{title && titleType && (
+					<BlockHeading
+						className="c-block-three-clickable-tiles__title u-text-ellipsis--2"
+						type={titleType}
+					>
+						{title}
+					</BlockHeading>
+				)}
+				<div className="c-block-three-clickable-tiles__icon">
 					<Icon name="arrowRight" />
 				</div>
 			</div>
-		);
-		return !isNil(link) ? (
-			<SmartLink
-				key={`c-block-three-clickable-tiles-${i}`}
-				className="c-block-three-clickable-tiles__term c-block-three-clickable-tiles__link"
-				action={link}
-			>
-				{element}
-			</SmartLink>
-		) : (
-			<div
-				key={`c-block-three-clickable-tiles-${i}`}
-				className="c-block-three-clickable-tiles__term"
-			>
-				{element}
-			</div>
-		);
-	};
+		</article>
+	);
 
 	return (
 		<div className={classnames('c-block-three-clickable-tiles', className)}>
 			{elements.map(
-				({ link, subtitle, imgSource }: BlockClickableTilesProps, i: number): ReactNode =>
-					renderTile(link, subtitle, imgSource, i)
+				(tile: BlockClickableTilesProps, i: number): ReactNode =>
+					isNil(tile?.link) ? (
+						renderTile(tile, i)
+					) : (
+						<SmartLink
+							key={`c-block-three-clickable-tiles-${i}`}
+							className="c-block-three-clickable-tiles__link"
+							action={tile.link}
+						>
+							{renderTile(tile, i)}
+						</SmartLink>
+					)
 			)}
 		</div>
 	);

--- a/ui/src/react-admin/modules/content-page/types/content-block.types.ts
+++ b/ui/src/react-admin/modules/content-page/types/content-block.types.ts
@@ -440,8 +440,9 @@ export interface TagsWithLinkBlockComponentState {
 }
 
 export interface ThreeClickableTilesBlockComponentState {
-	subtitle: string;
-	source: string;
+	title: string;
+	titleType: HeadingTypeOption;
+	image: string;
 	link?: ButtonAction;
 }
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1676
https://meemoo.atlassian.net/browse/ARC-1677
https://meemoo.atlassian.net/browse/ARC-1678

Extra changes (WCAG/A11Y):
- added a heading type selector since we can't know the outline structure which means we can't use a fixed heading element.
- render the image as an actual image asset instead of a background

This PR is part of a group of PRs:
- https://github.com/viaacode/hetarchief-client/pull/875
- https://github.com/viaacode/react-admin-core-module/pull/176

https://user-images.githubusercontent.com/77958553/236777899-1f84c00e-98d8-46a2-bb36-db111df63436.mov