### PR TITLE
fix(arc-1737): fix content block margin collapse on safari

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/ContentBlockRenderer/ContentBlockRenderer.tsx
+++ b/ui/src/react-admin/modules/content-page/components/ContentBlockRenderer/ContentBlockRenderer.tsx
@@ -6,7 +6,7 @@ import React, { FunctionComponent, RefObject, useCallback, useEffect, useRef } f
 import { generateSmartLink } from '~shared/components/SmartLink/SmartLink';
 
 import { GET_DARK_BACKGROUND_COLOR_OPTIONS } from '../../const/get-color-options';
-import { Color, ContentBlockConfig } from '../../types/content-block.types';
+import { Color, ContentBlockConfig, CustomBackground } from '../../types/content-block.types';
 
 import {
 	CONTENT_PAGE_ACCESS_BLOCKS,
@@ -119,10 +119,17 @@ const ContentBlockRenderer: FunctionComponent<ContentBlockPreviewProps> = ({
 			className={clsx(
 				'c-content-block',
 				className,
-				'c-content-block__' + kebabCase(contentBlockConfig.type)
+				'c-content-block__' + kebabCase(contentBlockConfig.type),
+				{
+					'c-content-block__meemoo-custom-background':
+						blockState.backgroundColor === CustomBackground.MeemooLogo, // https://meemoo.atlassian.net/browse/ARC-1237
+				}
 			)}
 			style={{
-				background: blockState.backgroundColor,
+				background:
+					blockState.backgroundColor === CustomBackground.MeemooLogo
+						? Color.Transparent
+						: blockState.backgroundColor,
 				...(blockState.headerBackgroundColor !== Color.Transparent ? { zIndex: 1 } : {}),
 			}}
 			id={blockState.anchor}

--- a/ui/src/react-admin/modules/content-page/components/ContentPageRenderer/ContentPageRenderer.scss
+++ b/ui/src/react-admin/modules/content-page/components/ContentPageRenderer/ContentPageRenderer.scss
@@ -1,6 +1,13 @@
 // Avoid collapsing padding and margins: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
+// We tried
+// * overflow: hidden => causes issues on the homepage of the avo with the search dropdown being cut off
+// * We tried a margin of 0.05px => which causes a single pixel line between blocks with the same background
+// * We tried display flex => which causes issues on safari with blocks: https://meemoo.atlassian.net/browse/ARC-1737
+//
+// * Latest solution: try negative margins of 0.05px
 .c-content-page-preview {
-	display: flex;
-	flex-direction: column;
-	width: 100%;
+	padding-top: -0.05px;
+	padding-bottom: -0.05px;
+	margin-top: -0.05px;
+	margin-bottom: -0.05px;
 }

--- a/ui/src/react-admin/modules/content-page/components/blocks/defaults.ts
+++ b/ui/src/react-admin/modules/content-page/components/blocks/defaults.ts
@@ -17,6 +17,7 @@ import {
 	Color,
 	ContentBlockEditor,
 	ContentBlockField,
+	CustomBackground,
 	DefaultContentBlockState,
 	GradientColor,
 	PaddingFieldState,
@@ -101,7 +102,7 @@ export const FOREGROUND_COLOR_FIELD = (
 
 export const BACKGROUND_COLOR_FIELD = (
 	label: string,
-	defaultValue: SelectOption<Color | GradientColor>
+	defaultValue: SelectOption<Color | GradientColor | CustomBackground>
 ): ContentBlockField => ({
 	label,
 	editorType: ContentBlockEditor.ColorSelect,

--- a/ui/src/react-admin/modules/content-page/const/get-color-options.ts
+++ b/ui/src/react-admin/modules/content-page/const/get-color-options.ts
@@ -1,6 +1,6 @@
 import { SelectOption } from '@viaa/avo2-components';
 import { AdminConfigManager } from '~core/config';
-import { Color, GradientColor } from '../types/content-block.types';
+import { Color, CustomBackground, GradientColor } from '../types/content-block.types';
 
 const transparentOption = () => ({
 	label: AdminConfigManager.getConfig().services.i18n.tText(
@@ -92,6 +92,10 @@ const skyBlueOption = () => ({
 	),
 	value: Color.SkyBlue,
 });
+const meemooLogoOption = () => ({
+	label: AdminConfigManager.getConfig().services.i18n.tText('meemoo logo'),
+	value: CustomBackground.MeemooLogo,
+});
 const blackWhiteGradientOption = () => ({
 	label: AdminConfigManager.getConfig().services.i18n.tText(
 		'modules/content-page/const/content-block___overgang-zwart-wit'
@@ -113,7 +117,7 @@ export const GET_BACKGROUND_COLOR_OPTIONS_AVO: () => SelectOption<Color>[] = () 
 ];
 
 export const GET_BACKGROUND_COLOR_OPTIONS_ARCHIEF: () => SelectOption<
-	Color | GradientColor
+	Color | GradientColor | CustomBackground
 >[] = () => [
 	transparentOption(),
 	whiteOption(),
@@ -122,6 +126,7 @@ export const GET_BACKGROUND_COLOR_OPTIONS_ARCHIEF: () => SelectOption<
 	platinumOption(),
 	blackOption(),
 	skyBlueOption(),
+	meemooLogoOption(),
 	blackWhiteGradientOption(),
 ];
 
@@ -134,7 +139,11 @@ export const GET_HERO_BACKGROUND_COLOR_OPTIONS: () => SelectOption<Color>[] = ()
 	yellowOption(),
 ];
 
-export const GET_DARK_BACKGROUND_COLOR_OPTIONS: () => Color[] = () => [
+export const GET_DARK_BACKGROUND_COLOR_OPTIONS: () => (
+	| Color
+	| GradientColor
+	| CustomBackground
+)[] = () => [
 	Color.SoftBlue,
 	Color.NightBlue,
 	Color.Teal,

--- a/ui/src/react-admin/modules/content-page/types/content-block.types.ts
+++ b/ui/src/react-admin/modules/content-page/types/content-block.types.ts
@@ -89,6 +89,10 @@ export enum GradientColor {
 	BlackWhite = 'linear-gradient(to top, #fff 0%, #fff calc(100% - 16rem), #000 calc(100% - 16rem), #000 100%)',
 }
 
+export enum CustomBackground {
+	MeemooLogo = '<MEEMOO_LOGO>',
+}
+
 export const ColorSelectGradientColors: Record<GradientColor, string> = {
 	[GradientColor.BlackWhite]: 'linear-gradient(to top, #fff 0%, #fff 50%, #000 50%, #000 100%)',
 };
@@ -194,7 +198,7 @@ export interface ContentBlockFieldGroup {
 
 /* CONTENT BLOCK STATE */
 export interface DefaultContentBlockState {
-	backgroundColor: Color;
+	backgroundColor: Color | GradientColor | CustomBackground;
 	headerBackgroundColor?: Color; // css color string. eg: '#222' or 'black' or 'rgb(0, 0, 255)'
 	headerHeight?: string; // css height string. eg: '20px' or '15%'
 	padding: PaddingFieldState;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1737

content blocks should now be displayed correctly on safari 15.x

![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/20b41def-8f8d-4213-9e3b-2fb51aac9644)
