### PR TITLE
fix(arc-1443): sort page overview labels according to entry order

### DIFF
--- a/ui/src/react-admin/core/config/config.types.ts
+++ b/ui/src/react-admin/core/config/config.types.ts
@@ -1,7 +1,6 @@
 import type { Avo } from '@viaa/avo2-types';
 import { DatabaseType } from '@viaa/avo2-types';
 import { ComponentType, FC, FunctionComponent, MouseEvent, ReactNode } from 'react';
-import { MediaListItem } from '~content-blocks/BlockMediaGrid/BlockMediaGrid';
 
 import { UserBulkAction } from '~modules/user/user.types';
 

--- a/ui/src/react-admin/modules/alerts/views/AlertsOverview.tsx
+++ b/ui/src/react-admin/modules/alerts/views/AlertsOverview.tsx
@@ -489,7 +489,7 @@ const AlertsOverview: FunctionComponent<AlertsOverviewProps> = ({ className, ren
 			// Reset the form when the blade is closed
 			reset(getDefaultValues());
 		}
-	}, [activeAlert]);
+	}, [activeAlert, getDefaultValues, reset]);
 
 	const renderTitle = useMemo(() => {
 		return (

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHetArchiefHeaderSearch/BlockHetArchiefHeaderSearch.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHetArchiefHeaderSearch/BlockHetArchiefHeaderSearch.tsx
@@ -38,7 +38,7 @@ export const BlockHetArchiefHeaderSearch: FunctionComponent<BlockHetArchiefHeade
 				clearInterval(timerId);
 			}
 		};
-	}, []);
+	}, [subtitles.length]);
 
 	const navigateToSearchPage = () => {
 		const url = stringifyUrl({

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
@@ -1,6 +1,6 @@
 import { IconName } from '@viaa/avo2-components';
 import type { Avo } from '@viaa/avo2-types';
-import { cloneDeep, compact, isNil, isNumber, isString } from 'lodash-es';
+import { cloneDeep, compact, isNil, isNumber, isString, sortBy } from 'lodash-es';
 import { FunctionComponent, useEffect } from 'react';
 import { NumberParam, QueryParamConfig, StringParam, useQueryParams } from 'use-query-params';
 import {
@@ -186,8 +186,16 @@ export const BlockPageOverviewWrapper: FunctionComponent<PageOverviewWrapperProp
 	};
 
 	const getLabelsWithContent = () => {
-		return (labelObjs || []).filter(
+		const labelsWithAtLeastOnePage = (labelObjs || []).filter(
 			(labelObj: LabelObj) => (labelPageCounts || {})[labelObj.id] > 0
+		);
+		// Sort labels in the order they were entered in the admin-core content page editor:
+		// https://meemoo.atlassian.net/browse/ARC-1443?focusedCommentId=40802
+		const labelIds = (contentTypeAndTabs.selectedLabels || []).map((labelId) =>
+			String(labelId)
+		);
+		return sortBy(labelsWithAtLeastOnePage, (labelObj) =>
+			labelIds.indexOf(String(labelObj.id))
 		);
 	};
 

--- a/ui/src/react-admin/modules/content-page/helpers/field-attributes.ts
+++ b/ui/src/react-admin/modules/content-page/helpers/field-attributes.ts
@@ -3,7 +3,6 @@ import { RichTextEditorProps } from '@meemoo/react-components';
 import { compact, debounce, get, isArray, isNil } from 'lodash-es';
 import { ContentPickerProps } from '~shared/components/ContentPicker/ContentPicker';
 
-import { PickerItem } from '../../shared/types/content-picker';
 import { ContentBlockEditor, ContentBlockField } from '../types/content-block.types';
 import { RichEditorStateKey } from '~modules/content-page/const/rich-text-editor.consts';
 

--- a/ui/src/react-admin/modules/shared/components/Icon/Icon.tsx
+++ b/ui/src/react-admin/modules/shared/components/Icon/Icon.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 
 import { AdminConfigManager } from '~core/config';
-import { IconConfig } from '~core/config/config.types';
 
 interface IconProps {
 	name: string;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1443

before:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/c2f177cb-bc26-49cc-9b8b-5ba1e6d293df)


after:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/cf6e08d7-8155-4efa-bdf9-75df1c3220d5)
