### PR TITLE
fix(arc-1748): strip content page label fields before trying to update

### DIFF
--- a/ui/src/react-admin/modules/content-page-labels/content-page-label.service.ts
+++ b/ui/src/react-admin/modules/content-page-labels/content-page-label.service.ts
@@ -70,6 +70,7 @@ export class ContentPageLabelService {
 				body: JSON.stringify({
 					label: contentPageLabel.label,
 					content_type: contentPageLabel.content_type,
+					link_to: contentPageLabel.link_to,
 				}),
 			});
 		} catch (err) {
@@ -85,7 +86,12 @@ export class ContentPageLabelService {
 		try {
 			return fetchWithLogoutJson(this.getBaseUrl(), {
 				method: 'PATCH',
-				body: JSON.stringify(contentPageLabelInfo),
+				body: JSON.stringify({
+					id: contentPageLabelInfo.id,
+					label: contentPageLabelInfo.label,
+					content_type: contentPageLabelInfo.content_type,
+					link_to: contentPageLabelInfo.link_to,
+				}),
 			});
 		} catch (err) {
 			throw new CustomError('Failed to update content page label in the database', err, {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1748

before:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/7cef9b99-f8a5-4c48-adbc-35a8d55732b8)


after:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/e97ebd18-566d-4d2f-88f9-868bd9272093)
