### PR TITLE
fix(arc-1306): add link to cards without description block + scaling

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockCardsWithoutDescription/BlockCardsWithoutDescription.editorconfig.ts
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockCardsWithoutDescription/BlockCardsWithoutDescription.editorconfig.ts
@@ -1,4 +1,5 @@
 import { GET_CARD_WITHOUT_DESCRIPTION_STYLE_OPTIONS } from '~modules/content-page/const/get-card-without-description-style-options';
+import { ContentPickerType } from '~shared/components/ContentPicker/ContentPicker.types';
 import {
 	CardWithoutDescriptionBlockComponentState,
 	Color,
@@ -93,6 +94,18 @@ export const CARDS_WITHOUT_DESCRIPTION_BLOCK_CONFIG = (position = 0): ContentBlo
 					? GET_BACKGROUND_COLOR_OPTIONS_AVO()[1]
 					: GET_BACKGROUND_COLOR_OPTIONS_ARCHIEF()[1]
 			),
+			linkAction: {
+				label: AdminConfigManager.getConfig().services.i18n.tText('Tegel link'),
+				editorType: ContentBlockEditor.ContentPicker,
+				editorProps: {
+					allowedTypes: [
+						ContentPickerType.CONTENT_PAGE,
+						ContentPickerType.INTERNAL_LINK,
+						ContentPickerType.EXTERNAL_LINK,
+						ContentPickerType.ANCHOR_LINK,
+					],
+				},
+			},
 		},
 	},
 	block: {

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockCardsWithoutDescription/BlockCardsWithoutDescription.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockCardsWithoutDescription/BlockCardsWithoutDescription.tsx
@@ -1,8 +1,11 @@
-import { Image } from '@viaa/avo2-components';
+import { ButtonAction, Image } from '@viaa/avo2-components';
 import classnames from 'classnames';
+import clsx from 'clsx';
+import { divide } from 'lodash-es';
 import { FunctionComponent, ReactElement, ReactNode } from 'react';
 import { CardWithoutDescriptionStyleOption } from '~modules/content-page/types/content-block.types';
 import { DefaultComponentProps } from '~modules/shared/types/components';
+import SmartLink from '~shared/components/SmartLink/SmartLink';
 
 export interface BlockCardWithoutDescriptionProps {
 	title: string;
@@ -10,6 +13,7 @@ export interface BlockCardWithoutDescriptionProps {
 	style: CardWithoutDescriptionStyleOption;
 	textColor: string;
 	backgroundColor: string;
+	linkAction?: ButtonAction;
 }
 
 export interface BlockCardsWithoutDescriptionProps extends DefaultComponentProps {
@@ -20,36 +24,66 @@ export const BlockCardsWithoutDescription: FunctionComponent<BlockCardsWithoutDe
 	className,
 	elements,
 }): ReactElement => {
+	const renderCardContent = ({
+		title,
+		style,
+		image,
+		backgroundColor,
+		textColor,
+	}: BlockCardWithoutDescriptionProps) => {
+		return (
+			<>
+				<p
+					style={{ color: textColor, backgroundColor }}
+					className="c-block-cards-without-description__title"
+				>
+					{title}
+				</p>
+				{image && (
+					<Image
+						src={image}
+						alt={title}
+						className={`c-block-cards-without-description__image c-block-cards-without-description__image--${style}`}
+					/>
+				)}
+			</>
+		);
+	};
+
 	const renderCard = (
-		{ title, style, image, backgroundColor, textColor }: BlockCardWithoutDescriptionProps,
+		{ linkAction, ...props }: BlockCardWithoutDescriptionProps,
 		i: number
-	): ReactElement => (
-		<div
-			className="c-block-cards-without-description__card"
-			key={`c-block-cards-without-description__card--${i}`}
-		>
-			<p
-				style={{ color: textColor, backgroundColor }}
-				className="c-block-cards-without-description__title"
-			>
-				{title}
-			</p>
-			{image && (
-				<Image
-					src={image}
-					alt={title}
-					className={`c-block-cards-without-description__image c-block-cards-without-description__image--${style}`}
-				/>
-			)}
-		</div>
-	);
+	): ReactElement => {
+		if (linkAction) {
+			return (
+				<SmartLink
+					action={linkAction}
+					className="c-block-cards-without-description__card"
+					key={`c-block-cards-without-description__card--${i}`}
+				>
+					{renderCardContent(props)}
+				</SmartLink>
+			);
+		} else {
+			return (
+				<div
+					className="c-block-cards-without-description__card"
+					key={`c-block-cards-without-description__card--${i}`}
+				>
+					{renderCardContent(props)}
+				</div>
+			);
+		}
+	};
 
 	return (
-		<div className={classnames('c-block-cards-without-description', className)}>
-			{elements.map(
-				(card: BlockCardWithoutDescriptionProps, i: number): ReactNode =>
-					renderCard(card, i)
-			)}
+		<div className={clsx('c-block-cards-without-description', className)}>
+			<div className="c-block-cards-without-description__elements-wrapper">
+				{elements.map(
+					(card: BlockCardWithoutDescriptionProps, i: number): ReactNode =>
+						renderCard(card, i)
+				)}
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1306

add option to add link to tiles and scale tiles to fix available space

before:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/3a7ea30e-e2ac-429f-a6d2-068461420d1a)


after:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/81d83b15-d05e-4a07-a5f4-fa1141b8e83b)
