### PR TITLE
fix(arc-1748): link_to type is not string + label change

### DIFF
--- a/api/src/modules/content-page-labels/dto/content-page-label.dto.ts
+++ b/api/src/modules/content-page-labels/dto/content-page-label.dto.ts
@@ -71,10 +71,8 @@ export class UpdateContentPageLabelDto {
 	})
 	content_type: ContentPageType;
 
-	@IsString()
 	@IsOptional()
 	@ApiProperty({
-		type: String,
 		required: false,
 	})
 	link_to?: PickerItemDto | null = null;

--- a/ui/src/react-admin/modules/content-page-labels/views/ContentPageLabelEdit.tsx
+++ b/ui/src/react-admin/modules/content-page-labels/views/ContentPageLabelEdit.tsx
@@ -178,7 +178,7 @@ const ContentPageLabelEdit: FunctionComponent<ContentPageLabelEditProps> = ({
 			AdminConfigManager.getConfig().services.toastService.showToast({
 				title: 'error',
 				description: AdminConfigManager.getConfig().services.i18n.tText(
-					'admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-de-permissiegroep-is-mislukt'
+					'admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-het-pagina-label-is-mislukt'
 				),
 				type: ToastType.ERROR,
 			});

--- a/ui/src/shared/translations/avo/nl.json
+++ b/ui/src/shared/translations/avo/nl.json
@@ -352,7 +352,7 @@
   "admin/content-page-labels/views/content-page-label-edit___de-invoer-is-ongeldig": "De invoer is ongeldig",
   "admin/content-page-labels/views/content-page-label-edit___een-label-is-verplicht": "Een label is verplicht",
   "admin/content-page-labels/views/content-page-label-edit___het-ophalen-van-de-content-pagina-label-is-mislukt": "Het ophalen van de content pagina label is mislukt",
-  "admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-de-permissiegroep-is-mislukt": "Het opslaan van de permissiegroep is mislukt",
+  "admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-het-pagina-label-is-mislukt": "Het opslaan van het pagina label is mislukt",
   "admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-het-content-pagina-label-is-mislukt-omdat-het-label-nog-niet-is-geladen": "Het opslaan van het content pagina label is mislukt omdat het label nog niet is geladen",
   "admin/content-page-labels/views/content-page-label-edit___label": "Label",
   "admin/content-page-labels/views/content-page-label-edit___link-naar": "Link naar",

--- a/ui/src/shared/translations/hetArchief/nl.json
+++ b/ui/src/shared/translations/hetArchief/nl.json
@@ -345,7 +345,7 @@
   "admin/content-page-labels/views/content-page-label-edit___de-invoer-is-ongeldig": "De invoer is ongeldig",
   "admin/content-page-labels/views/content-page-label-edit___een-label-is-verplicht": "Een label is verplicht",
   "admin/content-page-labels/views/content-page-label-edit___het-ophalen-van-de-content-pagina-label-is-mislukt": "Het ophalen van de content pagina label is mislukt",
-  "admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-de-permissiegroep-is-mislukt": "Het opslaan van de permissiegroep is mislukt",
+  "admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-het-pagina-label-is-mislukt": "Het opslaan van het pagina label is mislukt",
   "admin/content-page-labels/views/content-page-label-edit___het-opslaan-van-het-content-pagina-label-is-mislukt-omdat-het-label-nog-niet-is-geladen": "Het opslaan van het content pagina label is mislukt omdat het label nog niet is geladen",
   "admin/content-page-labels/views/content-page-label-edit___label": "Label",
   "admin/content-page-labels/views/content-page-label-edit___link-naar": "Link naar",


### PR DESCRIPTION
<img width="737" alt="image" src="https://github.com/viaacode/react-admin-core-module/assets/113892598/78235cae-a9ab-4c74-9758-8cfc85ac21c9">


Ticket: https://meemoo.atlassian.net/browse/ARC-1748