### PR TITLE
fix(ARC-1999): sort user groups in specific order

### DIFF
--- a/ui/src/react-admin/modules/shared/components/UserGroupSelect/UserGroupSelect.tsx
+++ b/ui/src/react-admin/modules/shared/components/UserGroupSelect/UserGroupSelect.tsx
@@ -1,5 +1,6 @@
 import { CheckboxGroup, FormGroup, TagInfo } from '@viaa/avo2-components';
-import { isEmpty } from 'lodash-es';
+import { TagInfoSchema } from '@viaa/avo2-components/dist/components/TagsInput/TagsInput';
+import { isEmpty, sortBy } from 'lodash-es';
 import React, { ChangeEvent, FunctionComponent } from 'react';
 
 import { Checkbox } from '@meemoo/react-components';
@@ -49,6 +50,28 @@ export const UserGroupSelect: FunctionComponent<UserGroupSelectProps> = ({
 		return parts.join(': ');
 	};
 
+	/**
+	 * sort the user groups in a specific order
+	 * https://meemoo.atlassian.net/browse/ARC-1999
+	 * @param userGroups
+	 */
+	const customSortUserGroups = (userGroups: TagInfoSchema[]) => {
+		return sortBy(userGroups, (userGroup) => {
+			const label = userGroup.label.toLowerCase();
+			if (label.includes('kiosk')) {
+				return '1-' + label;
+			} else if (label.includes('meemoo')) {
+				return '2-' + label;
+			} else if (label.includes('cp')) {
+				return '3-' + label;
+			} else if (label.includes('bezoeker')) {
+				return '4-' + label;
+			} else {
+				return '0-' + label;
+			}
+		});
+	};
+
 	if (isEmpty(userGroupOptions)) {
 		return null;
 	}
@@ -60,7 +83,7 @@ export const UserGroupSelect: FunctionComponent<UserGroupSelectProps> = ({
 			className="c-user-group-select"
 		>
 			<CheckboxGroup>
-				{userGroupOptions.map((userGroupOption) => {
+				{customSortUserGroups(userGroupOptions).map((userGroupOption) => {
 					return (
 						<Checkbox
 							key={userGroupOption.value}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1999


before:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/d02442da-6659-4f41-814a-95c64656154a)



after:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/07f7a039-6d4e-4f23-9dad-3873a14e9838)
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/2cfa1bcc-535f-43f6-b2fd-778bca0f84b1)
