### PR TITLE
fix(arc-2013): convert to BE time to show correct status

### DIFF
--- a/ui/src/react-admin/modules/alerts/views/AlertsOverview.tsx
+++ b/ui/src/react-admin/modules/alerts/views/AlertsOverview.tsx
@@ -112,8 +112,8 @@ const AlertsOverview: FunctionComponent<AlertsOverviewProps> = ({ className, ren
 		}
 
 		return isWithinInterval(new Date(), {
-			start: parseISO(from),
-			end: parseISO(till),
+			start: parseISO(from + 'Z'), // Force date to be interpreted as a GMT time from the database => parse it as a Europe/Brussels time in the date object
+			end: parseISO(till + 'Z'),
 		});
 	};
 

--- a/ui/src/react-admin/modules/alerts/views/AlertsOverview.tsx
+++ b/ui/src/react-admin/modules/alerts/views/AlertsOverview.tsx
@@ -35,6 +35,7 @@ import { DateInput } from '~shared/components/DateInput/DateInput';
 import timepicker from '~shared/components/Timepicker/Timepicker';
 import Timepicker from '~shared/components/Timepicker/Timepicker';
 import { timePickerDefaults } from '~shared/components/Timepicker/Timepicker.consts';
+import { parseAsIsoWithoutTimezone } from '~shared/helpers/formatters/date';
 import { OrderDirection } from '~shared/types';
 import {
 	ALERTS_FORM_SCHEMA,
@@ -112,8 +113,8 @@ const AlertsOverview: FunctionComponent<AlertsOverviewProps> = ({ className, ren
 		}
 
 		return isWithinInterval(new Date(), {
-			start: parseISO(from + 'Z'), // Force date to be interpreted as a GMT time from the database => parse it as a Europe/Brussels time in the date object
-			end: parseISO(till + 'Z'),
+			start: parseAsIsoWithoutTimezone(from),
+			end: parseAsIsoWithoutTimezone(till),
 		});
 	};
 
@@ -341,10 +342,10 @@ const AlertsOverview: FunctionComponent<AlertsOverviewProps> = ({ className, ren
 			title: activeAlert?.title || '',
 			message: activeAlert?.message || '',
 			fromDate: activeAlert?.fromDate
-				? new Date(activeAlert?.fromDate + 'Z') // Force date to be interpreted as a GMT time from the database => parse it as a Europe/Brussels time in the date object
+				? parseAsIsoWithoutTimezone(activeAlert?.fromDate)
 				: new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0),
 			untilDate: activeAlert?.untilDate
-				? new Date(activeAlert?.untilDate + 'Z')
+				? parseAsIsoWithoutTimezone(activeAlert?.untilDate)
 				: new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59),
 			userGroups: activeAlert?.userGroups || [],
 			type: activeAlert?.type || '',

--- a/ui/src/react-admin/modules/shared/helpers/formatters/date.ts
+++ b/ui/src/react-admin/modules/shared/helpers/formatters/date.ts
@@ -69,3 +69,15 @@ export function toDateObject(timestamp: DateLikeNullable): Date | null {
 	}
 	return normalizeTimestamp(timestamp);
 }
+
+/**
+ * Force date to be interpreted as a GMT time without timezone from the database => parse it as a Europe/Brussels time in the date object
+ * @param timestamp
+ */
+export function parseAsIsoWithoutTimezone(timestamp: string): Date {
+	if (!timestamp.endsWith('Z')) {
+		return parseISO(timestamp + 'Z');
+	} else {
+		return parseISO(timestamp);
+	}
+}


### PR DESCRIPTION
Current time:
- <img width="127" alt="image" src="https://github.com/viaacode/react-admin-core-module/assets/113892598/81d691a3-eb91-455c-b973-11a834b12ca3">


- <img width="1106" alt="image" src="https://github.com/viaacode/react-admin-core-module/assets/113892598/cc3ff542-9924-4e64-b7d8-d6801a5c4e3a">
- <img width="431" alt="image" src="https://github.com/viaacode/react-admin-core-module/assets/113892598/6b20b0e4-7945-463a-ab76-4017155b700d">


Ticket: https://meemoo.atlassian.net/browse/ARC-2013