### PR TITLE
fix(AVO-2987): don't set label query param if value is empty

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
@@ -156,7 +156,10 @@ export const BlockPageOverviewWrapper: FunctionComponent<PageOverviewWrapperProp
 
 	// ARC-1877: fix queryparams state on initial load was an old value (or undefined)
 	useEffect(() => {
-		setQueryParamsState(queryParamsState);
+		setQueryParamsState({
+			...queryParamsState,
+			label: queryParamsState?.label?.length ? queryParamsState.label : undefined,
+		});
 		// eslint-disable-next-line
 	}, []);
 

--- a/ui/src/react-admin/modules/shared/helpers/query-string-converters.ts
+++ b/ui/src/react-admin/modules/shared/helpers/query-string-converters.ts
@@ -42,7 +42,8 @@ export const CheckboxListParam = {
 			if (isArray(value)) {
 				return value as string[];
 			}
-			return value.split('~');
+			const newValues = value.split('~');
+			return newValues?.length ? newValues : undefined;
 		} catch (err) {
 			return;
 		}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2987

the issue was with the combination of the anchor block and the page overview block on a single page

page overview block would set ?label= on the url, even though the value was empty
the anchor link block would navigate to #inspiratie, after which the page overview block would again set ?label=
But if the value of label is empty it shouldn't be present in the url at all


it also helps to reproduce the issue on QAS, since then you can identify that the anchor block by itself works correctly.
eg: http://localhost:3400/admin/content/221

example of probelmatic page on qas:
http://localhost:3400/admin/content/2196


before:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/893ab1ea-dfc6-4038-87e4-6cc38ad2eb8c)


after:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/0696cc33-5a0e-4b96-bbcb-dbc3d5906026)
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/a6752528-45ca-4eb6-9589-aab2cd34975a)
