### PR TITLE
fix(AVO-3032): ensure page overview block labels are linked correctly

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.tsx
@@ -124,7 +124,7 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 	};
 
 	const renderLabel = (labelObj: any) => {
-		const labelLink = getLabelLink && getLabelLink(labelObj.label);
+		const labelLink = getLabelLink?.(labelObj.label);
 		if (labelLink) {
 			return `<a href="${labelLink}" class="c-content-page__label">${labelObj.label}</a>`;
 		}

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
@@ -243,9 +243,11 @@ export const BlockPageOverviewWrapper: FunctionComponent<PageOverviewWrapperProp
 				focusedPage={focusedPage ?? null}
 				onFocusedPageChanged={handleFocusedPageChanged}
 				getLabelLink={(label: string) => {
-					return `/${AdminConfigManager.getAdminRoute('NEWS')}?label=${encodeURIComponent(
-						label
-					)}`;
+					let newsLink = AdminConfigManager.getAdminRoute('NEWS');
+					if (!newsLink.startsWith('/') && !newsLink.includes('//')) {
+						newsLink = '/' + newsLink;
+					}
+					return `${newsLink}?label=${encodeURIComponent(label)}`;
 				}}
 				renderLink={renderLink}
 				commonUser={commonUser}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3032

my steps to debug content block issues:
* reproduce it on qas: https://onderwijs-qas.hetarchief.be/admin/content/222
* its a content block issue, so see if you can reproduce it on the admin-core alone for the same QAS page: http://localhost:3400/admin/content/222
* We can, so it is an admin-core only bug
* investigate the url: it has a double leading slash
	* ![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/da648dab-c1a2-47cf-92fc-0558cc295ed9)
* find the location where the link is created:
* search for the class that ends with -block higher up in the hierarchy:
* or search for the class of the label: c-content-page__label
* the link always gets a slash appended, but if it already has one, it creates a double slash => so it is interpreted as an absolute url (https:// also has a double slash)
```typescript
getLabelLink={(label: string) => {
	return `/${AdminConfigManager.getAdminRoute('NEWS')}?label=${encodeURIComponent(
		label
	)}`;
}}
```
* fix the double slash
