### PR TITLE
feat(AVO-3021): add link options to image block

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.editorconfig.ts
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.editorconfig.ts
@@ -1,7 +1,9 @@
+import { ButtonAction, ButtonType } from '@viaa/avo2-components';
 import { GET_ALIGN_OPTIONS } from '~modules/content-page/const/get-align-options';
 import { GET_WIDTH_OPTIONS } from '~modules/content-page/const/get-media-player-width-options';
 import { FileUploadProps } from '~shared/components/FileUpload/FileUpload';
 import {
+	AlignOption,
 	ContentBlockConfig,
 	ContentBlockEditor,
 	ContentBlockType,
@@ -9,7 +11,7 @@ import {
 	ImageBlockComponentState,
 } from '../../../types/content-block.types';
 
-import { BLOCK_FIELD_DEFAULTS, BLOCK_STATE_DEFAULTS, FILE_FIELD } from '../defaults';
+import { BLOCK_FIELD_DEFAULTS, BLOCK_STATE_DEFAULTS, FILE_FIELD, TEXT_FIELD } from '../defaults';
 
 import { AdminConfigManager } from '~core/config';
 
@@ -75,6 +77,76 @@ export const IMAGE_BLOCK_CONFIG = (position = 0): ContentBlockConfig => ({
 				label: AdminConfigManager.getConfig().services.i18n.tText(
 					'admin/content-block/helpers/generators/image___alignatie'
 				),
+				editorType: ContentBlockEditor.Select,
+				editorProps: {
+					options: GET_ALIGN_OPTIONS(),
+				},
+			},
+			imageAction: {
+				label: AdminConfigManager.getConfig().services.i18n.tText(
+					'Link achter de afbeelding'
+				),
+				editorType: ContentBlockEditor.ContentPicker,
+				editorProps: {
+					allowedTypes: [
+						'ITEM',
+						'COLLECTION',
+						'BUNDLE',
+						'ASSIGNMENT',
+						'CONTENT_PAGE',
+						'PROJECTS',
+						'INTERNAL_LINK',
+						'EXTERNAL_LINK',
+						'ANCHOR_LINK',
+						'FILE',
+					],
+				},
+			},
+			imageAlt: TEXT_FIELD(undefined, {
+				label: AdminConfigManager.getConfig().services.i18n.tText(
+					'Alt tekst voor de afbeelding'
+				),
+				editorType: ContentBlockEditor.TextInput,
+				validator: undefined,
+			}),
+			buttonType: {
+				label: AdminConfigManager.getConfig().services.i18n.tText('Knop type'),
+				editorType: ContentBlockEditor.Select,
+				editorProps: {
+					options: AdminConfigManager.getConfig().components.buttonTypes(),
+				},
+			},
+			buttonLabel: TEXT_FIELD(
+				AdminConfigManager.getConfig().services.i18n.tText('Knoptekst is verplicht'),
+				{
+					label: AdminConfigManager.getConfig().services.i18n.tText('Knop tekst'),
+					editorType: ContentBlockEditor.TextInput,
+				}
+			),
+			buttonAltTitle: TEXT_FIELD(undefined, {
+				label: AdminConfigManager.getConfig().services.i18n.tText('Alt knop text'),
+				editorType: ContentBlockEditor.TextInput,
+			}),
+			buttonAction: {
+				label: AdminConfigManager.getConfig().services.i18n.tText('Knop actie'),
+				editorType: ContentBlockEditor.ContentPicker,
+				editorProps: {
+					allowedTypes: [
+						'ITEM',
+						'COLLECTION',
+						'BUNDLE',
+						'ASSIGNMENT',
+						'CONTENT_PAGE',
+						'PROJECTS',
+						'INTERNAL_LINK',
+						'EXTERNAL_LINK',
+						'ANCHOR_LINK',
+						'FILE',
+					],
+				},
+			},
+			buttonAlign: {
+				label: AdminConfigManager.getConfig().services.i18n.tText('Knop alignatie'),
 				editorType: ContentBlockEditor.Select,
 				editorProps: {
 					options: GET_ALIGN_OPTIONS(),

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.scss
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.scss
@@ -1,4 +1,5 @@
 @import "../../../../shared/styles/settings/colors";
+@import "../../../../shared/styles/settings/variables";
 
 .o-block-image {
 	padding-top: 0;
@@ -33,6 +34,28 @@
 			position: absolute;
 			top: calc(100% + 10px);
 			left: 0;
+		}
+	}
+
+	.o-block-image__wrapper {
+		position: relative;
+
+		.o-block-image__button {
+			position: absolute;
+			bottom: $g-spacer-unit;
+
+			&--left {
+				left: $g-spacer-unit;
+			}
+
+			&--center {
+				left: 50%;
+				transform: translateX(-50%);
+			}
+
+			&--right {
+				right: $g-spacer-unit;
+			}
 		}
 	}
 }

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.tsx
@@ -1,26 +1,50 @@
-import { AlignOptions, Container, DefaultProps, Image } from '@viaa/avo2-components';
+import {
+	AlignOptions,
+	Button,
+	ButtonAction,
+	ButtonType,
+	Container,
+	DefaultProps,
+	Image,
+} from '@viaa/avo2-components';
 import clsx from 'clsx';
 import React, { CSSProperties, FunctionComponent } from 'react';
+import { AlignOption } from '~modules/content-page/types/content-block.types';
 
 import './BlockImage.scss';
+import SmartLink, { generateSmartLink } from '~shared/components/SmartLink/SmartLink';
 
 export interface BlockImageProps extends DefaultProps {
 	imageSource: string;
 	imageDescription?: string;
+	imageAction?: ButtonAction;
+	imageAlt?: string;
 	title?: string;
 	text?: string;
 	width?: 'page-header' | 'full-width' | string;
 	align?: AlignOptions;
+	buttonAction?: ButtonAction;
+	buttonAlt?: string;
+	buttonLabel?: string;
+	buttonType?: ButtonType;
+	buttonAlign?: AlignOption;
 }
 
 export const BlockImage: FunctionComponent<BlockImageProps> = ({
 	className,
 	imageSource,
 	imageDescription = '',
+	imageAction,
+	imageAlt,
 	title = '',
 	text = '',
 	width = '100%',
 	align = 'center',
+	buttonAlign,
+	buttonAction,
+	buttonAlt,
+	buttonLabel,
+	buttonType,
 }) => {
 	const style: CSSProperties = {};
 	if (width === 'page-header') {
@@ -32,6 +56,20 @@ export const BlockImage: FunctionComponent<BlockImageProps> = ({
 	} else {
 		style.width = width;
 	}
+
+	const renderImageContent = () => {
+		return (
+			<>
+				{width !== 'page-header' && (
+					<Image
+						src={imageSource}
+						alt={imageAlt || imageDescription || title || text}
+						wide
+					/>
+				)}
+			</>
+		);
+	};
 
 	return (
 		<Container
@@ -46,9 +84,27 @@ export const BlockImage: FunctionComponent<BlockImageProps> = ({
 			)}
 			style={style as any}
 		>
-			{width !== 'page-header' && (
-				<Image src={imageSource} alt={imageDescription || title || text} wide />
-			)}
+			<div className="o-block-image__wrapper">
+				{/* image itself with or without link */}
+				{!!imageAction && (
+					<SmartLink action={imageAction} title={imageAlt}>
+						{renderImageContent()}
+					</SmartLink>
+				)}
+				{!imageAction && renderImageContent()}
+				{/* button on top of image */}
+				{buttonAction &&
+					generateSmartLink(
+						buttonAction,
+						<Button label={buttonLabel} type={buttonType} />,
+						buttonAlt || buttonLabel,
+						clsx('o-block-image__button', {
+							[`o-block-image__button--${buttonAlign}`]: !!buttonAlign,
+						})
+					)}
+			</div>
+
+			{/* image author attribution */}
 			{(!!title || !!text) && (
 				<div className="a-block-image__annotation">
 					{title && <h3>&#169; {title}</h3>}

--- a/ui/src/react-admin/modules/shared/components/SmartLink/SmartLink.tsx
+++ b/ui/src/react-admin/modules/shared/components/SmartLink/SmartLink.tsx
@@ -215,10 +215,11 @@ export default SmartLink;
 export const generateSmartLink = (
 	action: ButtonAction | null | undefined,
 	children: ReactNode,
-	title?: string
+	title?: string,
+	className?: string
 ): ReactElement<any, any> | null => {
 	return (
-		<SmartLink action={action} title={title}>
+		<SmartLink action={action} title={title} className={className}>
 			{children}
 		</SmartLink>
 	);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3021

![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/eca1c736-bb5c-4dfa-a7a7-992f78e008ba)
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/27c94558-6791-4015-9e6c-cc2321d7cfc7)
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/85a18e3f-c108-4d95-ab6e-0ea41078588c)
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/43461041-fba8-410c-8508-d1999a80637b)
