### PR TITLE
fix(AVO-3038): delete labels before inserting content page labels

### DIFF
--- a/api/src/modules/content-pages/controllers/content-pages.controller.ts
+++ b/api/src/modules/content-pages/controllers/content-pages.controller.ts
@@ -199,6 +199,8 @@ export class ContentPagesController {
 				);
 			}
 		}
+		// Delete before inserting to avoid foreign key duplicate exceptions
+		await this.contentPagesService.deleteContentLabelsLinks(body.contentPageId, body.labelIds);
 		await this.contentPagesService.insertContentLabelsLinks(body.contentPageId, body.labelIds);
 	}
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3038

to avoid duplicate key exceptions
