### PR TITLE
fix(AVO-3021): set default button alignment on image block

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.editorconfig.ts
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockImage/BlockImage.editorconfig.ts
@@ -1,9 +1,7 @@
-import { ButtonAction, ButtonType } from '@viaa/avo2-components';
 import { GET_ALIGN_OPTIONS } from '~modules/content-page/const/get-align-options';
 import { GET_WIDTH_OPTIONS } from '~modules/content-page/const/get-media-player-width-options';
 import { FileUploadProps } from '~shared/components/FileUpload/FileUpload';
 import {
-	AlignOption,
 	ContentBlockConfig,
 	ContentBlockEditor,
 	ContentBlockType,
@@ -18,8 +16,11 @@ import { AdminConfigManager } from '~core/config';
 export const INITIAL_IMAGE_COMPONENTS_STATE = (): ImageBlockComponentState => ({
 	title: '',
 	text: '',
-	source: '',
+	imageSource: '',
+	imageAlt: '',
+	align: 'center',
 	width: 'full-width',
+	buttonAlign: 'left',
 });
 
 export const INITIAL_IMAGE_BLOCK_STATE = (): DefaultContentBlockState =>

--- a/ui/src/react-admin/modules/content-page/types/content-block.types.ts
+++ b/ui/src/react-admin/modules/content-page/types/content-block.types.ts
@@ -236,8 +236,16 @@ export interface HeadingBlockComponentState {
 export interface ImageBlockComponentState {
 	title: string;
 	text: string;
-	source: string;
+	imageSource: string;
 	width: WidthOption;
+	align: AlignOption;
+	imageAction?: ButtonAction;
+	imageAlt: string;
+	buttonType?: ButtonType;
+	buttonLabel?: string;
+	buttonAltTitle?: string;
+	buttonAction?: string;
+	buttonAlign?: AlignOption;
 }
 
 export interface ImageGridBlockComponentStateFields {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3021

before:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/bc2dfd28-40a2-46a5-be7b-049b4b67a47b)


after:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/518a3e8c-ff4b-4f9a-ab42-d06f86236378)

