### PR TITLE
fix(AVO-3104): only enable drag-and-drop when all accordions are closed

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/ContentBlockForm/ContentBlockForm.tsx
+++ b/ui/src/react-admin/modules/content-page/components/ContentBlockForm/ContentBlockForm.tsx
@@ -245,7 +245,7 @@ const ContentBlockForm: FunctionComponent<ContentBlockFormProps> = ({
 				</AccordionTitle>
 				<AccordionActions>
 					<ButtonToolbar>
-						<ButtonGroup>
+						<ButtonGroup className='u-nowrap'>
 							<Button
 								disabled={blockIndex === 0}
 								icon={'chevronUp' as IconName}

--- a/ui/src/react-admin/modules/content-page/components/DraggableList/DraggableList.scss
+++ b/ui/src/react-admin/modules/content-page/components/DraggableList/DraggableList.scss
@@ -26,7 +26,6 @@ $ghostHeight: 0.5rem;
 		opacity: 0.3;
 		padding: 1.2rem 1.8rem 1.2rem 1.2rem;
 		cursor: move;
-		position: absolute;
 	}
 
 	.c-draggable-list__item__content {

--- a/ui/src/react-admin/modules/content-page/components/DraggableList/DraggableList.tsx
+++ b/ui/src/react-admin/modules/content-page/components/DraggableList/DraggableList.tsx
@@ -161,7 +161,12 @@ const DraggableList: FunctionComponent<DraggableListProps> = ({
 					key={`draggable-list__item-${generateKey(item.data)}`}
 				>
 					<div className="c-draggable-list__item__content">
-						<div className="o-flex">{renderItem(item.data, item.index)}</div>
+						<div className="o-flex u-flex-align--center">
+							<div className="c-draggable-list__item__drag-handle">
+								<Icon name={IconName.menu} />
+							</div>
+							{renderItem(item.data, item.index)}
+						</div>
 					</div>
 				</div>
 			);

--- a/ui/src/react-admin/modules/content-page/views/ContentEditContentBlocks.scss
+++ b/ui/src/react-admin/modules/content-page/views/ContentEditContentBlocks.scss
@@ -25,15 +25,10 @@
 }
 
 .content-block-sidebar__items-non-draggable {
-	overflow: visible;
-	overflow-x: hidden;
-	overflow-y: hidden;
-
 	> .content-block-sidebar-item {
 		margin: 1rem 1rem;
 		background-color: #fff;
 		display: block;
 		position: relative;
-		width: 100%;
 	}
 }

--- a/ui/src/react-admin/modules/content-page/views/ContentEditContentBlocks.scss
+++ b/ui/src/react-admin/modules/content-page/views/ContentEditContentBlocks.scss
@@ -23,3 +23,17 @@
 .content-block-sidebar-item--highlighted {
 	border-color: $color-teal-bright;
 }
+
+.content-block-sidebar__items-non-draggable {
+	overflow: visible;
+	overflow-x: hidden;
+	overflow-y: hidden;
+
+	> .content-block-sidebar-item {
+		margin: 1rem 1rem;
+		background-color: #fff;
+		display: block;
+		position: relative;
+		width: 100%;
+	}
+}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3104

fix text cursor jumps to end, by only rendering drag and drop wrapper if all block accordions are collapsed:
https://github.com/viaacode/react-admin-core-module/assets/1710840/3c09bdc0-fa56-4df4-a6be-fac24eac93bd

fix scroll to:
https://github.com/viaacode/react-admin-core-module/assets/1710840/97c24f6f-4d31-4f8c-8425-8b4a0e06d24f

