### PR TITLE
fix(AVO-3113): return empty instead of untranslated string

### DIFF
--- a/ui/src/react-admin/modules/shared/components/ContentPicker/helpers/parse-picker.ts
+++ b/ui/src/react-admin/modules/shared/components/ContentPicker/helpers/parse-picker.ts
@@ -38,7 +38,7 @@ export const parseSearchQuery = (input: string): string => {
 			type: ToastType.ERROR,
 		});
 
-		return 'Ongeldige zoekfilter';
+		return '';
 	}
 };
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-3113

Mirror of https://github.com/viaacode/avo2-client/pull/1951