### PR TITLE
fix(ARC-1999): sort user groups according to preferred order for avo

### DIFF
--- a/api/src/modules/content-pages/controllers/content-pages.controller.ts
+++ b/api/src/modules/content-pages/controllers/content-pages.controller.ts
@@ -44,6 +44,11 @@ export class ContentPagesController {
 		private assetsService: AssetsService
 	) {}
 
+	/**
+	 * Fetches content pages to be shown in the PageOverviewBlock content block
+	 * @param queryDto
+	 * @param user
+	 */
 	@Post('')
 	public async getContentPagesForOverview(
 		@Body() queryDto: ContentPageOverviewParams,
@@ -52,6 +57,15 @@ export class ContentPagesController {
 		return this.contentPagesService.getContentPagesForOverview(queryDto, user.getGroupIds());
 	}
 
+	/**
+	 * Used to fetch content pages for the content page overview table in the admin dashboard
+	 * @param offset
+	 * @param limit
+	 * @param sortColumn
+	 * @param sortOrder
+	 * @param tableColumnDataType
+	 * @param where
+	 */
 	@Get('overview')
 	@RequireAnyPermissions(PermissionName.VIEW_ADMIN_DASHBOARD)
 	public async fetchContentPages(
@@ -314,6 +328,16 @@ export class ContentPagesController {
 		return this.contentPagesService.getUserGroupsFromContentPage(path);
 	}
 
+	/**
+	 * This function will accept an id of an existing content page
+	 * fetch the content page
+	 * duplicate all of the assets
+	 * and return the resulting content page json
+	 *
+	 * It doesn't save the content page in the database
+	 * @param id
+	 * @param user
+	 */
 	@Post('/duplicate/:id')
 	@RequireAnyPermissions(
 		PermissionName.EDIT_ANY_CONTENT_PAGES,

--- a/ui/src/react-admin/modules/shared/components/UserGroupSelect/UserGroupSelect.tsx
+++ b/ui/src/react-admin/modules/shared/components/UserGroupSelect/UserGroupSelect.tsx
@@ -50,6 +50,29 @@ export const UserGroupSelect: FunctionComponent<UserGroupSelectProps> = ({
 		return parts.join(': ');
 	};
 
+	const USER_GROUP_ORDER = [
+		// Hetarchief
+		'kiosk',
+		'meemoo',
+		'cp beheerder',
+		'bezoeker',
+		'meemoo beheerder',
+		// AVO
+		'leerling',
+		'lesgever',
+		'student lesgever',
+		'lesgever secundair',
+		'student lesgever secundair',
+		'educatieve auteur',
+		'educatieve uitgever',
+		'educatieve partner',
+		'contentpartner',
+		'redacteur',
+		'eindredacteur',
+		'medewerker meemoo',
+		'beheerder',
+	];
+
 	/**
 	 * sort the user groups in a specific order
 	 * https://meemoo.atlassian.net/browse/ARC-1999
@@ -58,17 +81,12 @@ export const UserGroupSelect: FunctionComponent<UserGroupSelectProps> = ({
 	const customSortUserGroups = (userGroups: TagInfoSchema[]) => {
 		return sortBy(userGroups, (userGroup) => {
 			const label = userGroup.label.toLowerCase();
-			if (label.includes('kiosk')) {
-				return '1-' + label;
-			} else if (label.includes('meemoo')) {
-				return '2-' + label;
-			} else if (label.includes('cp')) {
-				return '3-' + label;
-			} else if (label.includes('bezoeker')) {
-				return '4-' + label;
-			} else {
-				return '0-' + label;
+			let index = USER_GROUP_ORDER.findIndex((userGroupName) => userGroupName === label);
+			if (index === -1) {
+				index = 0;
 			}
+
+			return `${String(index).padStart(2, '0')}-${label}`;
 		});
 	};
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1999

before:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/780964fe-f19f-435e-933c-9f7af516e6cc)


after:
![image](https://github.com/viaacode/react-admin-core-module/assets/1710840/ee74c848-bca6-4912-b614-2f8b45c15832)


ideally we would save the display order somewhere in the database. But for now there isn't any budget for that, since the order changed without meemoo's request