### PR TITLE
fix(ARC-2117): add locale to tText function in admin-core-api

### DIFF
--- a/api/src/mock-user.ts
+++ b/api/src/mock-user.ts
@@ -1,7 +1,7 @@
 import type { Avo } from '@viaa/avo2-types';
 import { PermissionName } from '@viaa/avo2-types';
 
-import { type Idp, type LanguageCode } from './modules';
+import { type Idp, type Locale } from './modules';
 
 export const mockUserAvo: Avo.User.User = {
 	first_name: 'Bert',
@@ -11,7 +11,7 @@ export const mockUserAvo: Avo.User.User = {
 	is_blocked: false,
 	profile: {
 		id: '69ccef3b-751a-4be4-95bc-5ef365fbd504',
-		language: 'nl' as LanguageCode,
+		language: 'nl' as Locale,
 		alias: 'bert_verhelst',
 		title: 'Developer1',
 		alternative_email: 'verhelstbert@gmail.comaaaaaaa',

--- a/api/src/modules/assets/controllers/assets.controller.spec.ts
+++ b/api/src/modules/assets/controllers/assets.controller.spec.ts
@@ -3,7 +3,7 @@ import type { Avo } from '@viaa/avo2-types';
 
 import { mockUserAvo } from '../../../mock-user';
 import { mockTranslationsService } from '../../shared/helpers/mockTranslationsService';
-import { TranslationsService } from '../../translations';
+import { Locale, TranslationsService } from '../../translations';
 import { SessionUserEntity } from '../../users/classes/session-user';
 import { AssetsService } from '../services/assets.service';
 
@@ -48,7 +48,8 @@ describe('AssetsController', () => {
 
 			const response = await assetsController.uploadAsset(
 				{} as any,
-				{} as Avo.FileUpload.UploadAssetInfo
+				{} as Avo.FileUpload.UploadAssetInfo,
+				{ getLanguage: () => Locale.Nl } as any
 			);
 
 			expect(response).toEqual({

--- a/api/src/modules/assets/controllers/assets.controller.ts
+++ b/api/src/modules/assets/controllers/assets.controller.ts
@@ -83,12 +83,15 @@ export class AssetsController {
 	)
 	async uploadAsset(
 		@UploadedFile() file: any & { originalname: string; mimetype: string },
-		@Body() uploadAssetInfo: Avo.FileUpload.UploadAssetInfo
+		@Body() uploadAssetInfo: Avo.FileUpload.UploadAssetInfo,
+		@SessionUser() sessionUser: SessionUserEntity
 	): Promise<{ url: string }> {
 		if (!file) {
 			throw new BadRequestException(
 				this.translationsService.tText(
-					'modules/assets/controllers/assets___the-request-should-contain-a-file-to-upload'
+					'modules/assets/controllers/assets___the-request-should-contain-a-file-to-upload',
+					{},
+					sessionUser.getLanguage()
 				)
 			);
 		}

--- a/api/src/modules/content-page-labels/dto/content-page-label.dto.ts
+++ b/api/src/modules/content-page-labels/dto/content-page-label.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
 
 import { ContentPageType, ContentPickerType, LinkTarget } from '../../content-pages';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 
 export class PickerItemDto {
 	@IsString()
@@ -47,9 +47,9 @@ export class InsertContentPageLabelDto {
 	@IsString()
 	@ApiProperty({
 		type: String,
-		enum: LanguageCode,
+		enum: Locale,
 	})
-	language: LanguageCode;
+	language: Locale;
 
 	@IsString()
 	@IsOptional()
@@ -83,9 +83,9 @@ export class UpdateContentPageLabelDto {
 	@IsString()
 	@ApiProperty({
 		type: String,
-		enum: LanguageCode,
+		enum: Locale,
 	})
-	language: LanguageCode;
+	language: Locale;
 
 	@IsOptional()
 	@ApiProperty({
@@ -123,9 +123,9 @@ export class ContentPageLabelDto {
 	@IsString()
 	@ApiProperty({
 		type: String,
-		enum: LanguageCode,
+		enum: Locale,
 	})
-	language: LanguageCode;
+	language: Locale;
 
 	@IsString()
 	@ApiProperty({

--- a/api/src/modules/content-page-labels/mocks/content-page-labels.mocks.ts
+++ b/api/src/modules/content-page-labels/mocks/content-page-labels.mocks.ts
@@ -4,13 +4,13 @@ import {
 	type GetContentPageLabelsQuery,
 	Lookup_App_Content_Type_Enum,
 } from '../../shared/generated/graphql-db-types-hetarchief';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { type ContentPageLabelDto } from '../dto/content-page-label.dto';
 
 export const mockGqlContentPageLabel1: GetContentPageLabelsQuery['app_content_label'][0] = {
 	label: 'Gebruik van het materiaal',
 	content_type: Lookup_App_Content_Type_Enum.FaqItem,
-	language: LanguageCode.Nl,
+	language: Locale.Nl,
 	link_to: {
 		type: 'INTERNAL_LINK',
 		value: '/faq?label=Gebruik%20van%20het%20materiaal',
@@ -24,7 +24,7 @@ export const mockGqlContentPageLabel1: GetContentPageLabelsQuery['app_content_la
 export const mockGqlContentPageLabel2: GetContentPageLabelByIdQuery['app_content_label'][0] = {
 	label: 'Gebruik van het materiaal',
 	content_type: Lookup_App_Content_Type_Enum.FaqItem,
-	language: LanguageCode.Nl,
+	language: Locale.Nl,
 	link_to: {
 		type: 'INTERNAL_LINK',
 		value: '/faq?label=Gebruik%20van%20het%20materiaal',
@@ -40,7 +40,7 @@ export const mockContentPageLabel1: ContentPageLabel = {
 	content_type: Lookup_App_Content_Type_Enum.FaqItem,
 	id: '13d00f95-5597-4470-b5ce-d3ee96212ff4',
 	//id: 1,
-	language: LanguageCode.Nl,
+	language: Locale.Nl,
 	link_to: {
 		type: 'INTERNAL_LINK',
 		value: '/faq?label=Gebruik%20van%20het%20materiaal',
@@ -54,7 +54,7 @@ export const mockContentPageLabelDto: ContentPageLabelDto = {
 	label: 'Gebruik van het materiaal',
 	content_type: Lookup_App_Content_Type_Enum.FaqItem,
 	id: '13d00f95-5597-4470-b5ce-d3ee96212ff4',
-	language: LanguageCode.Nl,
+	language: Locale.Nl,
 	link_to: {
 		type: 'INTERNAL_LINK',
 		value: '/faq?label=Gebruik%20van%20het%20materiaal',

--- a/api/src/modules/content-pages/content-pages.types.ts
+++ b/api/src/modules/content-pages/content-pages.types.ts
@@ -15,7 +15,7 @@ import {
 	type GetContentPagesWithBlocksQuery as GetContentPagesWithBlocksQueryHetArchief,
 	Lookup_App_Content_Type_Enum,
 } from '../shared/generated/graphql-db-types-hetarchief';
-import { type LanguageCode } from '../translations';
+import { type Locale } from '../translations';
 
 import { type DbContentBlock } from './content-block.types';
 import { type ContentPageQueryTypes } from './queries/content-pages.queries';
@@ -54,7 +54,7 @@ export interface ContentPageLabel {
 	id: number | string;
 	label: string;
 	content_type: ContentPageType;
-	language: LanguageCode;
+	language: Locale;
 	link_to: PickerItem | null;
 	created_at: string;
 	updated_at: string;
@@ -64,7 +64,7 @@ interface ContentPageBase {
 	id: number | string;
 	thumbnailPath: string | null;
 	title: string;
-	language: LanguageCode;
+	language: Locale;
 	nlParentPageId: number | string;
 	description: string | null;
 	seoDescription: string | null;

--- a/api/src/modules/content-pages/controllers/content-pages.controller.ts
+++ b/api/src/modules/content-pages/controllers/content-pages.controller.ts
@@ -29,7 +29,7 @@ import { SessionUser } from '../../shared/decorators/user.decorator';
 import { ApiKeyGuard } from '../../shared/guards/api-key.guard';
 import { addPrefix } from '../../shared/helpers/add-route-prefix';
 import { logAndThrow } from '../../shared/helpers/logAndThrow';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { SessionUserEntity } from '../../users/classes/session-user';
 import { ContentOverviewTableCols, ContentPageLabel, DbContentPage } from '../content-pages.types';
 import { ContentPageOverviewParams } from '../dto/content-pages.dto';
@@ -94,7 +94,7 @@ export class ContentPagesController {
 		summary: 'Get content page by its path',
 	})
 	public async getContentPageByLanguageAndPath(
-		@Query('language') language: LanguageCode | undefined,
+		@Query('language') language: Locale | undefined,
 		@Query('path') path: string,
 		@Query('onlyInfo') onlyInfo: string,
 		@Req() request: Request,
@@ -103,7 +103,7 @@ export class ContentPagesController {
 	): Promise<DbContentPage> {
 		const user = sessionUser?.getUser();
 		return this.contentPagesService.getContentPageByLanguageAndPathForUser(
-			language || (user.language as LanguageCode),
+			language || (user.language as Locale),
 			path,
 			user,
 			request?.headers?.['Referrer'] as string,
@@ -114,7 +114,7 @@ export class ContentPagesController {
 
 	@Get('path-exists')
 	async doesContentPageExist(
-		@Query('language') language: LanguageCode,
+		@Query('language') language: Locale,
 		@Query('path') path: string,
 		@Req() request: Request,
 		@Ip() ip,

--- a/api/src/modules/content-pages/services/content-pages.service.ts
+++ b/api/src/modules/content-pages/services/content-pages.service.ts
@@ -46,7 +46,7 @@ import { App_Content_Block_Set_Input as App_Content_Block_Set_Input_HetArchief }
 import { CustomError } from '../../shared/helpers/custom-error';
 import { getDatabaseType } from '../../shared/helpers/get-database-type';
 import { isHetArchief } from '../../shared/helpers/is-hetarchief';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { ContentBlockType, DbContentBlock } from '../content-block.types';
 import {
 	DEFAULT_AUDIO_STILL,
@@ -224,7 +224,7 @@ export class ContentPagesService {
 			updated_at: contentPageInfo.updatedAt || null,
 			user_group_ids: contentPageInfo.userGroupIds.map((groupId) => String(groupId)),
 			user_profile_id: contentPageInfo.userProfileId,
-			language: contentPageInfo.language || LanguageCode.Nl,
+			language: contentPageInfo.language || Locale.Nl,
 			nl_parent_page_id: contentPageInfo.nlParentPageId || null,
 		};
 	}
@@ -377,7 +377,7 @@ export class ContentPagesService {
 	}
 
 	public async getContentPageByLanguageAndPath(
-		language: LanguageCode,
+		language: Locale,
 		path: string
 	): Promise<DbContentPage | null> {
 		const response = await this.dataService.execute<
@@ -396,7 +396,7 @@ export class ContentPagesService {
 	}
 
 	public async getContentPageByLanguageAndPathForUser(
-		language: LanguageCode,
+		language: Locale,
 		path: string,
 		user?: Avo.User.CommonUser,
 		referrer?: string,

--- a/api/src/modules/maintenance-alerts/dto/maintenance-alerts.dto.ts
+++ b/api/src/modules/maintenance-alerts/dto/maintenance-alerts.dto.ts
@@ -3,7 +3,7 @@ import { Type } from 'class-transformer';
 import { IsArray, IsNumber, IsOptional, IsString } from 'class-validator';
 
 import { SortDirection } from '../../shared/types';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { MaintenanceAlertOrderProp, MaintenanceAlertType } from '../maintenance-alerts.types';
 
 export class MaintenanceAlertsQueryDto {
@@ -130,9 +130,9 @@ export class CreateMaintenanceAlertDto {
 	@ApiPropertyOptional({
 		type: String,
 		description: 'Language of the maintenance alert',
-		enum: LanguageCode,
+		enum: Locale,
 	})
-	language: LanguageCode;
+	language: Locale;
 }
 
 export class UpdateMaintenanceAlertDto {
@@ -202,7 +202,7 @@ export class UpdateMaintenanceAlertDto {
 	@ApiPropertyOptional({
 		type: String,
 		description: 'Language of the maintenance alert',
-		enum: LanguageCode,
+		enum: Locale,
 	})
-	language: LanguageCode;
+	language: Locale;
 }

--- a/api/src/modules/maintenance-alerts/maintenance-alerts.types.ts
+++ b/api/src/modules/maintenance-alerts/maintenance-alerts.types.ts
@@ -4,7 +4,7 @@ import {
 	type InsertMaintenanceAlertMutation,
 	type UpdateMaintenanceAlertMutation,
 } from '../shared/generated/graphql-db-types-hetarchief';
-import { type LanguageCode } from '../translations';
+import { type Locale } from '../translations';
 
 export class MaintenanceAlert {
 	id: string;
@@ -14,7 +14,7 @@ export class MaintenanceAlert {
 	fromDate: string;
 	untilDate: string;
 	userGroups?: string[];
-	language: LanguageCode;
+	language: Locale;
 }
 
 export type GqlMaintenanceAlert =

--- a/api/src/modules/maintenance-alerts/services/maintenance-alerts.service.ts
+++ b/api/src/modules/maintenance-alerts/services/maintenance-alerts.service.ts
@@ -29,7 +29,7 @@ import {
 } from '../../shared/generated/graphql-db-types-hetarchief';
 import { PaginationHelper } from '../../shared/helpers/pagination';
 import { SortDirection } from '../../shared/types';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import {
 	CreateMaintenanceAlertDto,
 	MaintenanceAlertsQueryDto,
@@ -80,7 +80,7 @@ export class MaintenanceAlertsService {
 			);
 		}
 		if (languages?.length) {
-			whereAndFilter.push({ language: { _in: languages.split(',') as LanguageCode[] } });
+			whereAndFilter.push({ language: { _in: languages.split(',') as Locale[] } });
 		}
 		if (searchTerm) {
 			whereAndFilter.push({

--- a/api/src/modules/navigations/controllers/admin-navigations.controller.spec.ts
+++ b/api/src/modules/navigations/controllers/admin-navigations.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, type TestingModule } from '@nestjs/testing';
 
 import { type DeleteResponse } from '../../shared/types/types';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { AdminNavigationsService } from '../services/admin-navigations.service';
 
 import { AdminNavigationsController } from './admin-navigations.controller';
@@ -78,7 +78,7 @@ describe('NavigationsController', () => {
 				iconName: '',
 				placement: 'footer-links',
 				position: 1,
-				language: LanguageCode.Nl,
+				language: Locale.Nl,
 			});
 			expect(navigation).toEqual(mockNavigationsResponse.items[0]);
 		});
@@ -94,7 +94,7 @@ describe('NavigationsController', () => {
 				iconName: '',
 				placement: 'footer-links',
 				position: 1,
-				language: LanguageCode.Nl,
+				language: Locale.Nl,
 			});
 			expect(navigation).toEqual(mockNavigationsResponse.items[0]);
 		});

--- a/api/src/modules/navigations/controllers/admin-navigations.controller.ts
+++ b/api/src/modules/navigations/controllers/admin-navigations.controller.ts
@@ -7,7 +7,7 @@ import { RequireAnyPermissions } from '../../shared/decorators/require-any-permi
 import { SessionUser } from '../../shared/decorators/user.decorator';
 import { addPrefix } from '../../shared/helpers/add-route-prefix';
 import { DeleteResponse, SpecialPermissionGroups } from '../../shared/types/types';
-import { LanguageCode, Locale } from '../../translations';
+import { Locale } from '../../translations';
 import { SessionUserEntity } from '../../users/classes/session-user';
 import { CreateNavigationDto, UpdateNavigationDto } from '../dto/navigations.dto';
 import { NavigationItem } from '../navigations.types';
@@ -39,7 +39,7 @@ export class AdminNavigationsController {
 		@Query('language') language?: Locale
 	): Promise<Record<string, NavigationItem[]>> {
 		const allNavigationItems = await this.adminNavigationsService.findAllNavigationBarItems(
-			(language || Locale.nl) as unknown as LanguageCode
+			(language || Locale.Nl) as unknown as Locale
 		);
 
 		// filter based on logged in / logged out
@@ -119,7 +119,7 @@ export class AdminNavigationsController {
 	): Promise<NavigationItem[]> {
 		return await this.adminNavigationsService.findNavigationBarItemsByPlacementId(
 			placement,
-			(languages?.length ? languages.split(',') : []) as LanguageCode[],
+			(languages?.length ? languages.split(',') : []) as Locale[],
 			searchTerm
 		);
 	}

--- a/api/src/modules/navigations/dto/navigations.dto.ts
+++ b/api/src/modules/navigations/dto/navigations.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
 
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { ContentPickerTypesEnum, NavigationItem } from '../navigations.types';
 
 export class CreateNavigationDto implements Partial<NavigationItem> {
@@ -86,10 +86,10 @@ export class CreateNavigationDto implements Partial<NavigationItem> {
 	@IsString()
 	@ApiProperty({
 		type: String,
-		enum: LanguageCode,
+		enum: Locale,
 		description: 'The site language for which this navigation item should be shown',
 	})
-	language: LanguageCode;
+	language: Locale;
 
 	@IsString()
 	@IsOptional()
@@ -182,10 +182,10 @@ export class UpdateNavigationDto implements Partial<NavigationItem> {
 	@IsString()
 	@ApiProperty({
 		type: String,
-		enum: LanguageCode,
+		enum: Locale,
 		description: 'The site language for which this navigation item should be shown',
 	})
-	language: LanguageCode;
+	language: Locale;
 
 	@IsString()
 	@IsOptional()

--- a/api/src/modules/navigations/navigations.types.ts
+++ b/api/src/modules/navigations/navigations.types.ts
@@ -1,4 +1,4 @@
-import { type LanguageCode } from '../translations';
+import { type Locale } from '../translations';
 
 import { type NavigationQueryTypes } from './queries/navigation.queries';
 
@@ -28,7 +28,7 @@ export interface NavigationItem {
 	position: number;
 	contentType: string;
 	contentPath: string;
-	language: LanguageCode;
+	language: Locale;
 	tooltip?: string;
 	updatedAt: string;
 	createdAt: string;

--- a/api/src/modules/navigations/services/admin-navigations.service.spec.ts
+++ b/api/src/modules/navigations/services/admin-navigations.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 
 import { DataService } from '../../data';
 import { SpecialPermissionGroups } from '../../shared/types/types';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { type NavigationQueryTypes } from '../queries/navigation.queries';
 
 import { AdminNavigationsService } from './admin-navigations.service';
@@ -21,7 +21,7 @@ const mockNavigationElement1 = {
 	description: 'Navigatie balk in de footer gecentreerd',
 	created_at: '2022-02-21T16:36:06.045845+00:00',
 	content_id: null,
-	language: LanguageCode.Nl,
+	language: Locale.Nl,
 	tooltip: null,
 };
 
@@ -66,7 +66,7 @@ describe('NavigationsService', () => {
 		mockDataService.execute.mockResolvedValueOnce({ data: mockData });
 		const response = await navigationsService.findNavigationBarItemsByPlacementId(
 			mockNavigationElement1.placement,
-			[LanguageCode.Nl]
+			[Locale.Nl]
 		);
 		expect(response.length).toBe(1);
 		expect(response[0].placement).toEqual(mockNavigationElement1.placement);
@@ -117,7 +117,7 @@ describe('NavigationsService', () => {
 				iconName: 'plus',
 				placement: 'footer-links',
 				position: 1,
-				language: LanguageCode.Nl,
+				language: Locale.Nl,
 			});
 			expect(response.id).toBe('1');
 			expect(response.iconName).toBe('plus');
@@ -138,7 +138,7 @@ describe('NavigationsService', () => {
 				iconName: 'plus',
 				placement: 'footer-links',
 				position: 1,
-				language: LanguageCode.Nl,
+				language: Locale.Nl,
 			});
 			expect(response.id).toBe('1');
 			expect(response.iconName).toBe('plus');

--- a/api/src/modules/navigations/services/admin-navigations.service.ts
+++ b/api/src/modules/navigations/services/admin-navigations.service.ts
@@ -4,7 +4,7 @@ import { compact } from 'lodash';
 import { DataService } from '../../data';
 import { getDatabaseType } from '../../shared/helpers/get-database-type';
 import { DeleteResponse } from '../../shared/types/types';
-import { LanguageCode } from '../../translations';
+import { Locale } from '../../translations';
 import { CreateNavigationDto } from '../dto/navigations.dto';
 import { NavigationItem } from '../navigations.types';
 import {
@@ -127,7 +127,7 @@ export class AdminNavigationsService {
 
 	public async findNavigationBarItemsByPlacementId(
 		placement: string,
-		languages: LanguageCode[],
+		languages: Locale[],
 		searchTerm?: string
 	): Promise<NavigationItem[]> {
 		let navigationsResponse:
@@ -168,7 +168,7 @@ export class AdminNavigationsService {
 		).map(this.adapt);
 	}
 
-	public async findAllNavigationBarItems(language?: LanguageCode): Promise<NavigationItem[]> {
+	public async findAllNavigationBarItems(language?: Locale): Promise<NavigationItem[]> {
 		const navigationsResponse = await this.dataService.execute<
 			NavigationQueryTypes['GetAllNavigationItemsQuery'],
 			NavigationQueryTypes['GetAllNavigationItemsQueryVariables']

--- a/api/src/modules/shared/helpers/translation-fallback.ts
+++ b/api/src/modules/shared/helpers/translation-fallback.ts
@@ -22,14 +22,13 @@ export function getTranslationFallback(
 
 export function resolveTranslationVariables(
 	translation: string,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	variables: Record<string, string | number> = {}
+	variables?: Record<string, string | number> | undefined | null
 ): string {
 	let resolvedTranslation = translation;
-	Object.keys(variables).forEach((variableName) => {
+	Object.keys(variables || {}).forEach((variableName) => {
 		resolvedTranslation = resolvedTranslation.replace(
 			new RegExp(`{{${variableName}}}`, 'g'),
-			String(variables[variableName])
+			String((variables || {})[variableName])
 		);
 	});
 	return resolvedTranslation;

--- a/api/src/modules/status/services/status.service.ts
+++ b/api/src/modules/status/services/status.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import packageJson from '../../../../package.json';
 import { TranslationsService } from '../../translations';
-import { LanguageCode } from '../../translations/translations.types';
+import { Locale } from '../../translations/translations.types';
 
 @Injectable()
 export class StatusService {
@@ -27,9 +27,7 @@ export class StatusService {
 
 	private async getGraphQlStatus(): Promise<boolean> {
 		try {
-			const translations = await this.translationsService.getFrontendTranslations(
-				LanguageCode.Nl
-			);
+			const translations = await this.translationsService.getFrontendTranslations(Locale.Nl);
 
 			/* istanbul ignore next */
 			return !!Object.keys(translations)[0];

--- a/api/src/modules/translations/controllers/translations.controller.ts
+++ b/api/src/modules/translations/controllers/translations.controller.ts
@@ -8,8 +8,8 @@ import { UpdateTranslationDto } from '../dto/translations.dto';
 import { TranslationsService } from '../services/translations.service';
 import {
 	type KeyValueTranslations,
-	LanguageCode,
 	type LanguageInfo,
+	Locale,
 	MultiLanguageTranslationEntry,
 } from '../translations.types';
 
@@ -28,14 +28,14 @@ export class TranslationsController {
 		name: 'languageCode',
 		enum: [
 			// nl, en
-			...Object.values(LanguageCode),
+			...Object.values(Locale),
 		],
 	})
 	public async getTranslationsJson(
-		@Param('languageCode') languageCode: LanguageCode
+		@Param('languageCode') languageCode: Locale
 	): Promise<KeyValueTranslations> {
 		return this.translationsService.getFrontendTranslations(
-			languageCode.toLowerCase() as LanguageCode
+			languageCode.toLowerCase() as Locale
 		);
 	}
 

--- a/api/src/modules/translations/dto/translations.dto.ts
+++ b/api/src/modules/translations/dto/translations.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString } from 'class-validator';
-import { Lookup_Languages_Enum } from '../../shared/generated/graphql-db-types-hetarchief';
 
-import { Component, Key, LanguageCode, Location } from '../translations.types';
+import { Lookup_Languages_Enum } from '../../shared/generated/graphql-db-types-hetarchief';
+import { Component, Key, Locale, Location } from '../translations.types';
 
 export class UpdateTranslationDto {
 	@IsString()
@@ -38,13 +38,13 @@ export class UpdateTranslationDto {
 	@IsString()
 	@ApiProperty({
 		required: true,
-		enum: LanguageCode,
+		enum: Locale,
 		description:
 			'The language code of the current value. Possible values: ' +
 			Object.values(Lookup_Languages_Enum).join(', '),
 		example: 'EN',
 	})
-	languageCode: LanguageCode;
+	languageCode: Locale;
 
 	@IsString()
 	@ApiProperty({

--- a/api/src/modules/translations/services/translations.service.spec.ts
+++ b/api/src/modules/translations/services/translations.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, type TestingModule } from '@nestjs/testing';
 
 import { type UpdateResponse } from '../../shared/types/types';
 import { SiteVariablesService } from '../../site-variables';
-import { Component, LanguageCode } from '../translations.types';
+import { Component, Locale } from '../translations.types';
 
 import { TranslationsService } from './translations.service';
 
@@ -48,7 +48,7 @@ describe('TranslationsService', () => {
 				mockTranslationsResponse.value
 			);
 			// mockCacheManager.wrap.mockResolvedValueOnce(mockTranslationsResponse.value);
-			const translations = await translationsService.getFrontendTranslations(LanguageCode.Nl);
+			const translations = await translationsService.getFrontendTranslations(Locale.Nl);
 
 			expect(translations).toEqual(mockTranslationsResponse.value);
 		});
@@ -111,7 +111,7 @@ describe('TranslationsService', () => {
 				Component.FRONTEND,
 				'modules/admin/const/requests',
 				'status',
-				LanguageCode.Nl,
+				Locale.Nl,
 				'new value'
 			);
 			expect(response).toEqual({ affectedRows: 1 });

--- a/api/src/modules/translations/translations.types.ts
+++ b/api/src/modules/translations/translations.types.ts
@@ -32,11 +32,7 @@ export enum ValueType {
 	HTML = 'HTML',
 }
 
-export enum Locale {
-	nl = 'nl',
-	en = 'en',
-}
-export { Lookup_Languages_Enum as LanguageCode };
+export { Lookup_Languages_Enum as Locale };
 
 export interface TranslationEntry {
 	app: App;

--- a/api/src/modules/users/classes/session-user.ts
+++ b/api/src/modules/users/classes/session-user.ts
@@ -2,7 +2,7 @@ import { type Avo, type PermissionName } from '@viaa/avo2-types';
 
 import { isAvo } from '../../shared/helpers/is-avo';
 import { SpecialPermissionGroups } from '../../shared/types/types';
-import { type LanguageCode } from '../../translations';
+import { type Locale } from '../../translations';
 import { convertUserInfoToCommonUser } from '../users.converters';
 import { UserInfoType } from '../users.types';
 
@@ -30,8 +30,8 @@ export class SessionUserEntity {
 		return this.user.profileId;
 	}
 
-	public getLanguage(): LanguageCode | undefined {
-		return this.user?.language as LanguageCode | undefined;
+	public getLanguage(): Locale | undefined {
+		return this.user?.language as Locale | undefined;
 	}
 
 	public getFirstName(): string {

--- a/ui/src/react-admin/core/config/config.types.ts
+++ b/ui/src/react-admin/core/config/config.types.ts
@@ -1,3 +1,4 @@
+import { LinkTarget } from '@viaa/avo2-components';
 import type { Avo } from '@viaa/avo2-types';
 import { DatabaseType } from '@viaa/avo2-types';
 import { ComponentType, FC, FunctionComponent, MouseEvent, ReactNode } from 'react';
@@ -43,6 +44,7 @@ export interface LinkInfo {
 	onClick?: (evt: MouseEvent) => void;
 	title?: string;
 	children: ReactNode;
+	target?: LinkTarget;
 }
 
 export type History = ReturnType<AdminConfig['services']['router']['useHistory']>;

--- a/ui/src/react-admin/modules/maintenance-alerts/views/MaintenanceAlertsEditForm.tsx
+++ b/ui/src/react-admin/modules/maintenance-alerts/views/MaintenanceAlertsEditForm.tsx
@@ -88,16 +88,6 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		maintenanceAlert && reset(getDefaultValues());
 	}, [maintenanceAlert, getDefaultValues, reset]);
 
-	// useEffect(() => {
-	// 	setValue('title', form.title);
-	// 	setValue('message', form.message);
-	// 	setValue('fromDate', form.fromDate);
-	// 	setValue('untilDate', form.untilDate);
-	// 	setValue('userGroups', form.userGroups);
-	// 	setValue('type', form.type);
-	// 	setValue('language', form.language);
-	// }, [form, setValue]);
-
 	useEffect(() => {
 		if (isNil(maintenanceAlert)) {
 			// Reset the form when the blade is closed
@@ -165,7 +155,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		handleClose();
 	};
 
-	const renderTitle = useMemo(() => {
+	const renderedTitle = useMemo(() => {
 		return (
 			<FormControl
 				id="new-alert-title"
@@ -191,7 +181,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		);
 	}, [control, errors.title?.message, setValue]);
 
-	const renderMessage = useMemo(() => {
+	const renderedMessage = useMemo(() => {
 		return (
 			<FormControl
 				id="new-alert-message"
@@ -219,7 +209,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		);
 	}, [errors.message?.message, maintenanceAlert, control, getDefaultValues, setValue]);
 
-	const renderIcon = useMemo(() => {
+	const renderedIcon = useMemo(() => {
 		return (
 			<FormControl
 				id="new-alert-icon"
@@ -252,7 +242,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		);
 	}, [control, errors.type?.message, setValue]);
 
-	const renderUserGroup = useMemo(() => {
+	const renderedUserGroup = useMemo(() => {
 		return (
 			<FormControl
 				id="new-alert-user-group"
@@ -289,7 +279,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		);
 	}, [control, errors.userGroups?.message, setValue, userGroupOptions]);
 
-	const renderFrom = useMemo(() => {
+	const renderedFrom = useMemo(() => {
 		return (
 			<FormControl
 				id="new-alert-from-date"
@@ -356,7 +346,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		);
 	}, [control, errors.fromDate?.message, setValue]);
 
-	const renderUntil = useMemo(() => {
+	const renderedUntil = useMemo(() => {
 		return (
 			<FormControl
 				id="new-alert-until-date"
@@ -423,7 +413,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 		);
 	}, [control, errors.untilDate?.message, setValue]);
 
-	const renderLanguage = useMemo(() => {
+	const renderedLanguage = useMemo(() => {
 		return (
 			<FormControl
 				id="new-alert-language"
@@ -433,7 +423,7 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 				errors={[errors.language?.message]}
 			>
 				<Controller
-					name="type"
+					name="language"
 					control={control}
 					render={({ field }) => (
 						<ReactSelect
@@ -463,13 +453,13 @@ const MaintenanceAlertsEditForm: FunctionComponent<MaintenanceAlertsEditFormProp
 
 		return (
 			<>
-				{renderTitle}
-				{renderMessage}
-				{renderIcon}
-				{renderUserGroup}
-				{renderFrom}
-				{renderUntil}
-				{renderLanguage}
+				{renderedTitle}
+				{renderedMessage}
+				{renderedIcon}
+				{renderedUserGroup}
+				{renderedFrom}
+				{renderedUntil}
+				{renderedLanguage}
 			</>
 		);
 	};


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2117

part of a PR group:
* https://github.com/viaacode/react-admin-core-module/pull/258
* https://github.com/viaacode/hetarchief-client/pull/1146
* https://github.com/viaacode/hetarchief-proxy/pull/479

also renamed LanguageCode to Locale in admin-core-api
