### PR TITLE
feat(ARC-2197): fix issue with server side rendering of links

### DIFF
--- a/ui/src/react-admin/modules/shared/components/SmartLink/SmartLink.tsx
+++ b/ui/src/react-admin/modules/shared/components/SmartLink/SmartLink.tsx
@@ -1,4 +1,4 @@
-import { ButtonAction, LinkTarget } from '@viaa/avo2-components';
+import { ButtonAction } from '@viaa/avo2-components';
 import type { Avo } from '@viaa/avo2-types';
 import clsx from 'clsx';
 import { fromPairs, map } from 'lodash-es';
@@ -10,6 +10,7 @@ import { getAdminCoreApiUrl } from '~shared/helpers/get-proxy-url-from-admin-cor
 import { buildLink } from '~shared/helpers/link';
 import { insideIframe } from '../../helpers/inside-iframe';
 import { Link } from '../Link';
+import { LinkTarget } from './SmartLink.types';
 
 export interface SmartLinkProps {
 	action?: ButtonAction | null;
@@ -36,6 +37,8 @@ const SmartLink: FunctionComponent<SmartLinkProps> = ({
 			fullUrl = `//${url}`;
 		}
 
+		console.log('rendering smartlink with target: ' + target);
+
 		switch (target) {
 			case LinkTarget.Self:
 				// Open inside same tab
@@ -44,7 +47,7 @@ const SmartLink: FunctionComponent<SmartLinkProps> = ({
 					return (
 						<a
 							href={fullUrl}
-							target="_self"
+							target={target}
 							className={clsx(className, { 'a-link__no-styles': removeStyles })}
 							title={title}
 							onClick={() =>
@@ -65,6 +68,7 @@ const SmartLink: FunctionComponent<SmartLinkProps> = ({
 							!anchor && scrollTo({ top: 0 });
 						}}
 						title={title}
+						target={target}
 					>
 						{children}
 					</Link>

--- a/ui/src/react-admin/modules/shared/components/SmartLink/SmartLink.types.ts
+++ b/ui/src/react-admin/modules/shared/components/SmartLink/SmartLink.types.ts
@@ -1,0 +1,4 @@
+export enum LinkTarget {
+	Self = '_self',
+	Blank = '_blank',
+}


### PR DESCRIPTION
LinkTarget enum cannot be used cross package since the values will always be undefined
even though typescript does not complain
