### PR TITLE
fix(AVO-3142): ensure eventbrite can re-initialize on subsequent navigation

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockEventbrite/BlockEventbrite.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockEventbrite/BlockEventbrite.tsx
@@ -22,9 +22,12 @@ export const BlockEventbrite: FunctionComponent<BlockEventbriteProps> = ({
 	const elementId = `eventbrite-widget-modal-trigger-${eventId}`;
 
 	useEffect(() => {
-		const existingScript = document.getElementById(EVENTBRITE_SCRIPT_ID);
-		if (!existingScript) {
-			const script = document.createElement('script');
+		let script: HTMLScriptElement | null = document.getElementById(
+			EVENTBRITE_SCRIPT_ID
+		) as HTMLScriptElement | null;
+
+		if (!script) {
+			script = document.createElement('script');
 			script.src = 'https://www.eventbrite.com/static/widgets/eb_widgets.js';
 			script.id = EVENTBRITE_SCRIPT_ID;
 			document.body.appendChild(script);
@@ -38,6 +41,8 @@ export const BlockEventbrite: FunctionComponent<BlockEventbriteProps> = ({
 				});
 			};
 		}
+
+		return () => script.remove();
 	}, [elementId, eventId]);
 
 	return (


### PR DESCRIPTION
Steps to reproduce issue:

1. https://onderwijs-qas.hetarchief.be/workshops-en-events/webinars
2. open any detail page
3. press the register now button
4. cancel the registration
5. scroll to the bottom
6. press the return to overview button
7. open a different detail page
8. press the register now button again