### PR TITLE
fix(ARC-2470): avoid crash when overview block link doesn't exist

### DIFF
--- a/ui/src/react-admin/core/config/config.class.ts
+++ b/ui/src/react-admin/core/config/config.class.ts
@@ -22,4 +22,8 @@ export class AdminConfigManager {
 			})
 		);
 	}
+
+	public static hasAdminRoute(name: keyof AdminConfig['routes']): boolean {
+		return !!this.config.routes[name];
+	}
 }

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.scss
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.scss
@@ -49,7 +49,7 @@
 			font-size: 14px;
 		}
 
-		.c-content-page__label {
+		.c-content-page__label--link {
 			text-decoration: underline;
 			cursor: pointer;
 		}

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.tsx
@@ -126,7 +126,7 @@ export const BlockPageOverview: FunctionComponent<BlockPageOverviewProps> = ({
 	const renderLabel = (labelObj: any) => {
 		const labelLink = getLabelLink?.(labelObj.label);
 		if (labelLink) {
-			return `<a href="${labelLink}" class="c-content-page__label">${labelObj.label}</a>`;
+			return `<a href="${labelLink}" class="c-content-page__label c-content-page__label--link">${labelObj.label}</a>`;
 		}
 		return `<span class="c-content-page__label">${labelObj.label}</span>`;
 	};

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockPageOverview/BlockPageOverview.wrapper.tsx
@@ -245,13 +245,19 @@ export const BlockPageOverviewWrapper: FunctionComponent<PageOverviewWrapperProp
 				buttonAltTitle={buttonAltTitle}
 				focusedPage={focusedPage ?? null}
 				onFocusedPageChanged={handleFocusedPageChanged}
-				getLabelLink={(label: string) => {
-					let newsLink = AdminConfigManager.getAdminRoute('NEWS');
-					if (!newsLink.startsWith('/') && !newsLink.includes('//')) {
-						newsLink = '/' + newsLink;
-					}
-					return `${newsLink}?label=${encodeURIComponent(label)}`;
-				}}
+				getLabelLink={
+					AdminConfigManager.hasAdminRoute('NEWS')
+						? (label: string) => {
+								// AVO specific link to the news page
+								// This doesn't exist in hetarchief
+								let newsLink = AdminConfigManager.getAdminRoute('NEWS');
+								if (!newsLink.startsWith('/') && !newsLink.includes('//')) {
+									newsLink = '/' + newsLink;
+								}
+								return `${newsLink}?label=${encodeURIComponent(label)}`;
+						  }
+						: undefined
+				}
 				renderLink={renderLink}
 				commonUser={commonUser}
 				isLoadingLabelObjs={isLoadingLabelObjs}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2470

![image](https://github.com/user-attachments/assets/6331659e-877d-4d41-9e56-2c4fffd50b23)
