### PR TITLE
fix(ARC-2453): fix preview path for content pages for multilanguage

### DIFF
--- a/ui/src/react-admin/modules/content-page/views/ContentPageDetail.tsx
+++ b/ui/src/react-admin/modules/content-page/views/ContentPageDetail.tsx
@@ -191,12 +191,13 @@ export const ContentPageDetail: FC<ContentPageDetailProps> = ({
 
 	function handlePreviewClicked() {
 		if (contentPageInfo && contentPageInfo.path) {
-			if (isAvo()) {
-				// Do not add the locale to the path for AVO
+			if (contentPageInfo.language === Locale.Nl) {
+				// Do not add the locale to the path, since the default is dutch
 				navigateToAbsoluteOrRelativeUrl(contentPageInfo.path, history, LinkTarget.Blank);
 			} else {
+				// For english pages, add the locale to the path
 				navigateToAbsoluteOrRelativeUrl(
-					`/${AdminConfigManager.getConfig().locale}${contentPageInfo.path}`,
+					`/${contentPageInfo.language}${contentPageInfo.path}`,
 					history,
 					LinkTarget.Blank
 				);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2453

We need to use the language of the page, not the language of the website
also do not add language in the url if the page language is dutch

dutch:
![image](https://github.com/user-attachments/assets/540f7af9-341d-4e64-95bb-e6a2914e82dd)
![image](https://github.com/user-attachments/assets/7b18379d-2300-484d-83be-75892ee02549)

english:
![image](https://github.com/user-attachments/assets/66bd4a30-eb0d-4586-af29-1d752e6667c6)
![image](https://github.com/user-attachments/assets/ac7ba851-1a06-4c7e-a08c-bff5eb42b0db)


