### PR TITLE
fix(ARC-3723): fix gebruikersbeheer modal search bar styling

### DIFF
--- a/ui/src/react-admin/modules/shared/styles/components/_input.scss
+++ b/ui/src/react-admin/modules/shared/styles/components/_input.scss
@@ -71,7 +71,7 @@ textarea.c-input--h-large {
   }
 
   .o-svg-icon {
-		margin-left: 0.5rem;
+    margin-left: 0.5rem;
     top: 0.9rem;
     width: 1.8rem;
     height: 1.8rem;

--- a/ui/src/react-admin/modules/shared/styles/components/_input.scss
+++ b/ui/src/react-admin/modules/shared/styles/components/_input.scss
@@ -67,11 +67,11 @@ textarea.c-input--h-large {
   position: relative;
 
   .c-input {
-    padding-left: 3rem;
+    padding-left: 1rem;
   }
 
   .o-svg-icon {
-    position: absolute;
+		margin-left: 0.5rem;
     top: 0.9rem;
     width: 1.8rem;
     height: 1.8rem;


### PR DESCRIPTION
De rest van de "normale" search bars dat ik gevonden heb doorheen de applicatie zijn niet affected en zien er nog allemaal oke uit.

<img width="1001" height="646" alt="image" src="https://github.com/user-attachments/assets/07137e68-359f-4883-9183-8ddd4166e69d" />
