### PR TITLE
fix(AVO-4043): replace avo2 components tooltip with local version

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.scss
+++ b/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.scss
@@ -14,9 +14,19 @@
       right: 10px;
       top: 6px;
     }
-
-    .c-tooltip[data-popper-placement^="right"] > .c-tooltip__arrow {
-      left: -4px;
-    }
   }
+}
+
+.p-content-page-publish-modal {
+	.c-tooltip-component {
+		background-color: #edeff2;
+		border: 1px solid #557891;
+		border-radius: 0.3rem;
+		padding: 0.8rem;
+		color: black;
+		font-size: 1.2rem;
+		line-height: 1.428; // 20px equivalent
+		user-select: none;
+		pointer-events: none;
+		margin: 0 !important;	}
 }

--- a/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.scss
+++ b/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.scss
@@ -1,32 +1,5 @@
 .c-content-page-publish-modal__display-date {
-  margin-top: 3.2rem;
-
   .o-form-group__label {
     font-weight: 500;
   }
-
-  .u-spacer {
-    position: relative;
-    display: inline-block;
-
-    .c-tooltip-trigger {
-      position: absolute;
-      right: 10px;
-      top: 6px;
-    }
-  }
-}
-
-.p-content-page-publish-modal {
-	.c-tooltip-component {
-		background-color: #edeff2;
-		border: 1px solid #557891;
-		border-radius: 0.3rem;
-		padding: 0.8rem;
-		color: black;
-		font-size: 1.2rem;
-		line-height: 1.428; // 20px equivalent
-		user-select: none;
-		pointer-events: none;
-		margin: 0 !important;	}
 }

--- a/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.tsx
+++ b/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.tsx
@@ -1,3 +1,4 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@meemoo/react-components';
 import type { IconName } from '@viaa/avo2-components';
 import {
 	Button,
@@ -13,9 +14,6 @@ import {
 	Toolbar,
 	ToolbarItem,
 	ToolbarRight,
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
 } from '@viaa/avo2-components';
 import { parseISO, setHours, setMinutes, setSeconds } from 'date-fns';
 import type { FC } from 'react';
@@ -203,7 +201,12 @@ const PublishContentPageModal: FC<PublishContentPageModalProps> = ({
 								)
 							}
 						/>
-						<Tooltip position="right" id="publish-content-page-modal__published-at-display-tooltip">
+						<Tooltip
+							position="top"
+							arrowStrokeWidth={1}
+							arrowStrokeColor="#557891"
+							arrowFillColor="#edeff2"
+						>
 							<TooltipTrigger>
 								<Icon className="a-info-icon" name={'info' as IconName} size="small" />
 							</TooltipTrigger>

--- a/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.tsx
+++ b/ui/src/react-admin/modules/content-page/components/PublishContentPageModal.tsx
@@ -1,4 +1,3 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from '@meemoo/react-components';
 import type { IconName } from '@viaa/avo2-components';
 import {
 	Button,
@@ -22,6 +21,7 @@ import { BlockHeading } from '~content-blocks/BlockHeading/BlockHeading';
 import { ToastType } from '~core/config/config.types';
 import { getDatePickerDefaultProps } from '~modules/content-page/components/DatePicker/DatePicker.consts';
 import { getPublishedState } from '~modules/content-page/helpers/get-published-state';
+import { Tooltip, TooltipContent, TooltipTrigger } from '~shared/components/Tooltip/Tooltip.tsx';
 import { showToast } from '~shared/helpers/show-toast';
 import { tHtml, tText } from '~shared/helpers/translation-functions';
 import type { ContentPageInfo, PublishOption } from '../types/content-pages.types';
@@ -201,12 +201,7 @@ const PublishContentPageModal: FC<PublishContentPageModalProps> = ({
 								)
 							}
 						/>
-						<Tooltip
-							position="top"
-							arrowStrokeWidth={1}
-							arrowStrokeColor="#557891"
-							arrowFillColor="#edeff2"
-						>
+						<Tooltip position="top">
 							<TooltipTrigger>
 								<Icon className="a-info-icon" name={'info' as IconName} size="small" />
 							</TooltipTrigger>

--- a/ui/src/react-admin/modules/shared/components/Tooltip/Tooltip.scss
+++ b/ui/src/react-admin/modules/shared/components/Tooltip/Tooltip.scss
@@ -1,0 +1,27 @@
+@use "../../../shared/styles/settings/colors" as colors;
+
+.c-tooltip-avo {
+	background-color: colors.$color-gray-50;
+	border: 1px solid colors.$color-gray-400;
+	border-radius: 0.3rem;
+	padding: 0.8rem;
+	color: black;
+	font-size: 1.2rem;
+	line-height: 1.428; // 20px equivalent
+	margin: 0 !important;
+}
+
+.c-tooltip-hetarchief {
+	background-color: colors.$color-gray-1000;
+	border: 1px solid colors.$color-gray-1000;
+	max-width: 19rem !important;
+	padding: 0.5rem;
+	color: colors.$white;
+	font-size: 1.3rem;
+	font-weight: 100;
+	line-height: 1.428; // 20px equivalent
+	transition:
+			opacity 0.2s ease-in-out,
+			visibility 0.2s linear 0.2s;
+	margin: 0 !important;
+}

--- a/ui/src/react-admin/modules/shared/components/Tooltip/Tooltip.tsx
+++ b/ui/src/react-admin/modules/shared/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,49 @@
+import type { Placement } from '@floating-ui/react';
+import {
+	Tooltip as ReactCompTooltip,
+	TooltipContent,
+	TooltipTrigger,
+	useSlot,
+} from '@meemoo/react-components';
+import { clsx } from 'clsx';
+import React, { type CSSProperties, type FC, type ReactNode } from 'react';
+import { isAvo } from '~shared/helpers/is-avo.ts';
+
+import './Tooltip.scss';
+
+export { TooltipContent, TooltipTrigger } from '@meemoo/react-components';
+
+export interface TooltipProps {
+	children: ReactNode;
+	position?: Placement;
+	offset?: number;
+	contentClassName?: string;
+	style?: CSSProperties;
+}
+
+export const Tooltip: FC<TooltipProps> = ({
+	children,
+	position = 'top',
+	offset,
+	contentClassName,
+	style,
+}) => {
+	const triggerElement = useSlot(TooltipTrigger, children);
+	const contentElement = useSlot(TooltipContent, children);
+	return (
+		<ReactCompTooltip
+			position={position}
+			offset={offset}
+			arrowStrokeWidth={1}
+			// Setting styles like this as a workaround since styling depends on client that consumes the admin-core
+			// And styling cannot be done purely with css because of the floating ui tooltip arrow styles
+			arrowStrokeColor={isAvo() ? '#557891' : 'black'}
+			arrowFillColor={isAvo() ? '#edeff2' : 'black'}
+			contentClassName={clsx(isAvo() ? 'c-tooltip-avo' : 'c-tooltip-hetarchief', contentClassName)}
+			style={style}
+		>
+			<TooltipTrigger>{triggerElement}</TooltipTrigger>
+			<TooltipContent>{contentElement}</TooltipContent>
+		</ReactCompTooltip>
+	);
+};

--- a/ui/src/react-admin/modules/user/views/UserDetail.tsx
+++ b/ui/src/react-admin/modules/user/views/UserDetail.tsx
@@ -277,10 +277,6 @@ export const UserDetail: FC<UserDetailProps> = ({
 								['bio', tText('admin/users/views/user-detail___bio')],
 								['stamboek', tText('admin/users/views/user-detail___stamboek-nummer')],
 								['email', tText('admin/users/views/user-detail___primair-email-adres')],
-								[
-									'alternativeEmail',
-									tText('admin/users/views/user-detail___secundair-email-adres'),
-								],
 							])}
 							{renderDetailRow(
 								userGroup ? userGroup.label : '-',


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-4043

part of:
* https://github.com/viaacode/avo2-client/pull/2206
* https://github.com/viaacode/react-components/pull/137
* https://github.com/viaacode/react-admin-core-module/pull/345

using @meemoo/react-components tooltip

<img width="1185" height="851" alt="image" src="https://github.com/user-attachments/assets/d719db54-2170-473f-94a9-fb9fdc676569" />

<img width="1396" height="638" alt="image" src="https://github.com/user-attachments/assets/aca06c89-36e6-4c6d-b8ee-aab3937cbeac" />

