### PR TITLE
fix: fix startup with ipv4 instead of ipv6

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16852,24 +16852,6 @@
         }
       }
     },
-    "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -17084,24 +17066,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/watchpack": {

--- a/api/package.json
+++ b/api/package.json
@@ -117,5 +117,12 @@
   },
   "overrides": {
     "graphql": "16.6.0"
+  },
+  "allowScripts": {
+    "@nestjs/core@9.4.3": true,
+    "@swc/core@1.11.13": true,
+    "esbuild@0.27.2": true,
+    "fsevents@2.3.3": true,
+    "sharp@0.34.5": true
   }
 }

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -39,7 +39,8 @@ async function bootstrap() {
 	}
 
 	/** All good, start listening */
-	await app.listen(port);
+	await app.listen(port, '127.0.0.1');
+	console.info('Service running on localhost:', port);
 }
 
 bootstrap();


### PR DESCRIPTION
```
[Nest] 10385  - 07/06/2026, 11:05:56 AM     LOG [RouterExplorer] Mapped {/admin/items/ids, GET} route +0ms
[Nest] 10385  - 07/06/2026, 11:05:56 AM     LOG [RouterExplorer] Mapped {/admin/items/:id, GET} route +0ms
[Nest] 10385  - 07/06/2026, 11:05:56 AM     LOG [RoutesResolver] TableColumnPreferencesController {/admin/table-column-preferences}: +0ms
[Nest] 10385  - 07/06/2026, 11:05:56 AM     LOG [RouterExplorer] Mapped {/admin/table-column-preferences/:columnKey, GET} route +0ms
[Nest] 10385  - 07/06/2026, 11:05:56 AM     LOG [RouterExplorer] Mapped {/admin/table-column-preferences/:columnKey, POST} route +0ms
[Nest] 10385  - 07/06/2026, 11:05:56 AM     LOG [NestApplication] Nest application successfully started +321ms
Service running on localhost: 3300
```
