### PR TITLE
fix(ARC-3838):: handle 404 for non existant content page

### DIFF
--- a/api/src/modules/content-pages/controllers/content-pages.controller.ts
+++ b/api/src/modules/content-pages/controllers/content-pages.controller.ts
@@ -113,7 +113,7 @@ export class ContentPagesController {
 	): Promise<DbContentPage> {
 		try {
 			const user = sessionUser?.getUser();
-			return await this.contentPagesService.getContentPageByLanguageAndPathForUser(
+			const contentPage = await this.contentPagesService.getContentPageByLanguageAndPathForUser(
 				language || (user.language as Locale),
 				path,
 				user,
@@ -121,9 +121,13 @@ export class ContentPagesController {
 				ip,
 				onlyInfo === 'true'
 			);
+			if (!contentPage) {
+				throw new CustomError('ContentPage not found', null, {code: 'NOT_FOUND'}, 404);
+			}
+			return contentPage;
 			// biome-ignore lint/suspicious/noExplicitAny: error can be any type
 		} catch (err: any) {
-			if (err?.response?.additionalInfo?.code === 'NOT_FOUND') {
+			if (err?.response?.additionalInfo?.code === 'NOT_FOUND' || err?.statusCode === 404) {
 				throw new NotFoundException('The content page with path was not found');
 			}
 			const error = new CustomError('Failed to get content page by language and path', err, {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3838

when content page doesn't exist, throw a 404 exception


the client seems to reboot after an error where a content page doesn't exist. But the request to the backend returns a status code 200.

This PR ensures it's a status code 404