### PR TITLE
fix(ARC-3838): hardcode language list in api endpoint

### DIFF
--- a/api/src/modules/translations/controllers/translations.controller.ts
+++ b/api/src/modules/translations/controllers/translations.controller.ts
@@ -4,6 +4,7 @@ import { PermissionName } from '@viaa/avo2-types';
 
 import { RequireAllPermissions } from '../../shared/decorators/require-permissions.decorator';
 import { addPrefix } from '../../shared/helpers/add-route-prefix';
+import { isAvo } from '../../shared/helpers/is-avo';
 import { UpdateTranslationDto } from '../dto/translations.dto';
 import { TranslationsService } from '../services/translations.service';
 import {
@@ -43,7 +44,25 @@ export class TranslationsController {
 	 */
 	@Get('languages')
 	public async getLanguages(): Promise<LanguageInfo[]> {
-		return this.translationsService.getLanguages();
+		if (isAvo()) {
+			return [
+				{
+					languageCode: 'nl',
+					languageLabel: 'Nederlands',
+				},
+			];
+		}
+		// hetarchief
+		return [
+			{
+				languageCode: 'nl',
+				languageLabel: 'Nederlands',
+			},
+			{
+				languageCode: 'en',
+				languageLabel: 'English',
+			},
+		];
 	}
 
 	/**

--- a/api/src/modules/translations/controllers/translations.controller.ts
+++ b/api/src/modules/translations/controllers/translations.controller.ts
@@ -47,7 +47,7 @@ export class TranslationsController {
 		if (isAvo()) {
 			return [
 				{
-					languageCode: 'nl',
+					languageCode: Locale.Nl,
 					languageLabel: 'Nederlands',
 				},
 			];
@@ -55,11 +55,11 @@ export class TranslationsController {
 		// hetarchief
 		return [
 			{
-				languageCode: 'nl',
+				languageCode: Locale.Nl,
 				languageLabel: 'Nederlands',
 			},
 			{
-				languageCode: 'en',
+				languageCode: Locale.En,
 				languageLabel: 'English',
 			},
 		];


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3838
since getting it from the db is expensive, and this list never changes without also needing code changes to the whole application

some AI flagged this endpoint als being called a lot
and possibly causing performance issues

There is one interesting pattern in the current logs: around 10:57–10:58 UTC, there is a burst of requests to:

GET /admin/translations/languages

with many calls arriving very close together.

If something similar happened before earlier restarts, it could potentially saturate the Node/NestJS process, block the event loop, exhaust connections, or cause enough CPU/memory pressure that /status stops responding within the probe's 4-second timeout.
