### PR TITLE
fix(ARC-3838): restore error message for content page failed to load

### DIFF
--- a/ui/src/react-admin/modules/content-page/views/ContentPageDetail.tsx
+++ b/ui/src/react-admin/modules/content-page/views/ContentPageDetail.tsx
@@ -526,7 +526,7 @@ export const ContentPageDetail: FC<ContentPageDetailProps> = ({
 		<AdminLayout className={className} pageTitle={pageTitle}>
 			<AdminLayout.Back>
 				<Button type="borderless" onClick={onGoBack}>
-					<Icon name="chevronLeft"></Icon>
+					<Icon name="chevronLeft" />
 				</Button>
 			</AdminLayout.Back>
 			<AdminLayout.Actions>{renderContentActions()}</AdminLayout.Actions>

--- a/ui/src/react-admin/modules/shared/components/LoadingErrorLoadedComponent/LoadingErrorLoadedComponent.tsx
+++ b/ui/src/react-admin/modules/shared/components/LoadingErrorLoadedComponent/LoadingErrorLoadedComponent.tsx
@@ -3,7 +3,8 @@ import type { AvoAuthErrorActionButton } from '@viaa/avo2-types';
 import type { FunctionComponent, ReactElement, ReactNode } from 'react';
 import React from 'react';
 import { CenteredSpinner } from '~shared/components/Spinner/CenteredSpinner';
-import { tHtml } from '~shared/helpers/translation-functions';
+import { tHtml, tText } from '~shared/helpers/translation-functions';
+import ErrorView from '../error/ErrorView';
 
 export type LoadingState = 'loading' | 'loaded' | 'error';
 
@@ -46,24 +47,17 @@ export const LoadingErrorLoadedComponent: FunctionComponent<LoadingErrorLoadedCo
 	locationId,
 }) => {
 	const renderError = () => (
-		// <ErrorView
-		// 	message={
-		// 		loadingInfo.message ||
-		// 		t(
-		// 			'shared/components/loading-error-loaded-component/loading-error-loaded-component___er-is-iets-mis-gegaan-bij-het-laden-van-de-gegevens'
-		// 		)
-		// 	}
-		// 	icon={loadingInfo.icon || 'alertTriangle' as IconName}
-		// 	actionButtons={loadingInfo.actionButtons || ['home']}
-		// />
-		<>
-			locationId: {locationId}
-			<br />
-			{loadingInfo.message ||
-				tHtml(
+		<ErrorView
+			message={
+				loadingInfo.message ||
+				tText(
 					'shared/components/loading-error-loaded-component/loading-error-loaded-component___er-is-iets-mis-gegaan-bij-het-laden-van-de-gegevens'
-				)}
-		</>
+				)
+			}
+			icon={loadingInfo.icon || ('alertTriangle' as IconName)}
+			actionButtons={loadingInfo.actionButtons || ['home']}
+			locationId={locationId}
+		/>
 	);
 
 	// Render


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3838

example url:
http://localhost:3200/admin/content-pages/5


before:
<img width="1728" height="879" alt="2026-08-11_13-45-21" src="https://github.com/user-attachments/assets/9abec894-62e3-4cf7-af0e-c89152e5a0c6" />


after:
<img width="1728" height="879" alt="2026-08-11_13-44-25" src="https://github.com/user-attachments/assets/47436c57-c5a4-4c2f-b68e-00c3d8a90f07" />
