### PR TITLE
fix(ARC-3814): delete repeated field item in repeat content block

### DIFF
--- a/ui/src/react-admin/modules/shared/components/ContentPicker/ContentPicker.tsx
+++ b/ui/src/react-admin/modules/shared/components/ContentPicker/ContentPicker.tsx
@@ -130,6 +130,31 @@ export const ContentPicker: FunctionComponent<ContentPickerProps> = ({
 		}
 	}, [itemOptions, hasAppliedInitialItem, value]);
 
+	// Follow the `value` prop when it is changed from the outside, eg: when an entry is deleted from
+	// a repeated field, the values of the pickers after the deleted one shift up one position.
+	// Without this the picker would keep rendering the item it was initialised with.
+	useEffect(() => {
+		if (!hasAppliedInitialItem) {
+			return; // The effect above is still responsible for applying the initial item
+		}
+		setSelectedItem((currentSelectedItem: PickerItem | null) => {
+			if ((currentSelectedItem?.value || null) === (value?.value || null)) {
+				return currentSelectedItem; // Already in sync, most likely this component reported the change itself
+			}
+			if (!value?.value) {
+				return null;
+			}
+			// Prefer the fetched option, since it is guaranteed to have an up to date label
+			return (
+				setInitialItem(itemOptions, value) || {
+					label: value.label || '',
+					type: value.type,
+					value: value.value,
+				}
+			);
+		});
+	}, [value, itemOptions, hasAppliedInitialItem]);
+
 	// events
 	const onSelectType = async (selected: SingleValue<PickerTypeOption>) => {
 		if (selectedType !== selected) {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3814

fixes the issue when you delete an item from a repeated block, it would seems it deleted the last item instead of the one you actually deleted


What was actually wrong

handleFieldDelete was never the problem — I traced the full path (FieldGenerator → ContentBlockForm.handleChange → handleStateSave → SET_COMPONENTS_STATE in content-edit.reducer.ts:240) and deleting index 1 of [t0, t1, t2] correctly stores [t0, t2]. If you save the page after deleting, the right item is gone.

What you see is a reconciliation artifact:

Rows are keyed by array index (FieldGenerator.tsx:169), so shrinking 3 → 2 keeps mounted components 0 and 1 and unmounts the last one.
ContentPicker kept its selection in internal state and applied the value prop exactly once, guarded by hasAppliedInitialItem. So rows 0 and 1 never noticed that row 1's value had shifted from t1 to t2.
Result: state [t0, t2], UI showing t0, t1 — indistinguishable from "the last one got deleted".

The new effect makes the picker follow value whenever it changes from the outside, comparing on .value so a selection the picker reported itself is a no-op (no loop, no flicker). Other editors used in repeated fields are already prop-driven — RichTextEditor syncs via setContent on value change, FileUpload renders straight from urls.

Two notes:

Side effect, I think a good one: a stored value that isn't in the fetched option list now renders with its stored label instead of appearing blank. Previously setInitialItem returned undefined in that case and the picker showed nothing even though a value was saved.
This also fixes fieldsToResetOnChange, which sets a field to null — that reset never cleared the picker visually before either.