### PR TITLE
fix(content-pages): return false for exists endpoint when 404 exception

### DIFF
--- a/api/src/modules/content-pages/controllers/content-pages.controller.ts
+++ b/api/src/modules/content-pages/controllers/content-pages.controller.ts
@@ -4,7 +4,6 @@ import {
 	Delete,
 	ForbiddenException,
 	Get,
-	InternalServerErrorException,
 	Ip,
 	NotFoundException,
 	Param,
@@ -122,13 +121,23 @@ export class ContentPagesController {
 				onlyInfo === 'true'
 			);
 			if (!contentPage) {
-				throw new CustomError('ContentPage not found', null, {code: 'NOT_FOUND'}, 404);
+				throw new CustomError('ContentPage not found', null, { code: 'NOT_FOUND' }, 404);
 			}
 			return contentPage;
 			// biome-ignore lint/suspicious/noExplicitAny: error can be any type
 		} catch (err: any) {
 			if (err?.response?.additionalInfo?.code === 'NOT_FOUND' || err?.statusCode === 404) {
-				throw new NotFoundException('The content page with path was not found');
+				throw new CustomError(
+					'The content page with path was not found',
+					err,
+					{
+						language,
+						path,
+						onlyInfo,
+						code: 'NOT_FOUND',
+					},
+					404
+				);
 			}
 			const error = new CustomError('Failed to get content page by language and path', err, {
 				language,
@@ -151,14 +160,27 @@ export class ContentPagesController {
 		@Ip() ip: string,
 		@SessionUser() user: SessionUserEntity
 	): Promise<{ exists: boolean; title: string; id: number | string }> {
-		const contentPage = await this.getContentPageByLanguageAndPath(
-			language,
-			path,
-			'true',
-			request,
-			ip,
-			user
-		);
+		let contentPage: DbContentPage | null = null;
+		try {
+			contentPage = await this.getContentPageByLanguageAndPath(
+				language,
+				path,
+				'true',
+				request,
+				ip,
+				user
+			);
+		} catch (err) {
+			if ((err as CustomError)?.statusCode === 404) {
+				return {
+					exists: false,
+					title: '',
+					id: '',
+				};
+			}
+			throw err;
+		}
+
 		return {
 			exists: !!contentPage,
 			title: contentPage?.title ?? null,


### PR DESCRIPTION
recent changes for throwing a 404 when a content page doesn't exist
also cause the /content-pages/path-exists to throw a 404, but that endpoint should return {exists: false}