### PR TITLE
fix(ARC-3862): space the paragraphs in highlight text and homepage banner

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHighlightText/BlockHighlightText.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHighlightText/BlockHighlightText.tsx
@@ -55,8 +55,10 @@ export const BlockHighlightText: FunctionComponent<BlockHighlightTextProps> = ({
 						aria-hidden="true"
 					/>
 				</div>
+				{/* c-rich-text-editor__content gives the rich text output its standard styling,
+				    paragraph spacing included - see BlockRichText */}
 				<Html
-					className="c-block-highlight-text__content-text"
+					className={clsx('c-block-highlight-text__content-text', 'c-rich-text-editor__content')}
 					style={
 						{
 							'--pattern-color': isGradient ? Color.White : patternColor,
@@ -64,7 +66,7 @@ export const BlockHighlightText: FunctionComponent<BlockHighlightTextProps> = ({
 					}
 					content={content}
 					type="p"
-				></Html>
+				/>
 				<div className="c-block-highlight-text__pattern-slot c-block-highlight-text__pattern-slot--bottom">
 					<div
 						className="c-block-highlight-text__pattern c-block-highlight-text__pattern--right"

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHighlightText/BlockHighligtText.scss
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHighlightText/BlockHighligtText.scss
@@ -48,6 +48,16 @@ $pattern-mobile-overshoot: 15rem;
 			@media (max-width: variables.$g-bp4) {
 				padding: calc(#{variables.$g-spacer-unit} * 3) calc(#{variables.$g-spacer-unit} * 2.5) !important;
 			}
+
+			// The rich text paragraph margins space the paragraphs apart, but the box's own
+			// padding does the spacing at the top and the bottom.
+			> p:first-child {
+				margin-top: 0;
+			}
+
+			> p:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHomepageBanner/BlockHomepageBanner.scss
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHomepageBanner/BlockHomepageBanner.scss
@@ -68,6 +68,16 @@ $pattern-mobile-overshoot: 10rem;
 		&-text {
 			color: colors.$neutral;
 			@include typography.sofia-pro-body(true);
+
+			// The rich text paragraph margins space the paragraphs apart, but the title's
+			// padding does the spacing above the first one.
+			> p:first-child {
+				margin-top: 0;
+			}
+
+			> p:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHomepageBanner/BlockHomepageBanner.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHomepageBanner/BlockHomepageBanner.tsx
@@ -71,7 +71,13 @@ export const BlockHomepageBanner: FunctionComponent<BlockHomepageBannerProps> = 
 					<BlockHeading className="c-block-homepage-banner__content-title" type="h4">
 						{title}
 					</BlockHeading>
-					<Html className="c-block-homepage-banner__content-text" content={content} type="p"></Html>
+					{/* c-rich-text-editor__content gives the rich text output its standard styling,
+					    paragraph spacing included - see BlockRichText */}
+					<Html
+						className={clsx('c-block-homepage-banner__content-text', 'c-rich-text-editor__content')}
+						content={content}
+						type="p"
+					/>
 					<div className="c-block-homepage-banner__pattern-slot c-block-homepage-banner__pattern-slot--bottom">
 						<div
 							className="c-block-homepage-banner__pattern c-block-homepage-banner__pattern--right"


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3862

Highlight text and homepage banner now render their rich text with the c-rich-text-editor__content class, so paragraphs get their normal spacing.