### PR TITLE
fix(ARC-3863): keep tables in the sanitized rich text output

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHighlightText/BlockHighlightText.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHighlightText/BlockHighlightText.tsx
@@ -10,6 +10,7 @@ import {
 } from '~modules/content-page/types/content-block.types';
 import { ContentPageWidth } from '~modules/content-page/types/content-pages.types.ts';
 import Html from '~shared/components/Html/Html.tsx';
+import { SanitizePreset } from '~shared/helpers/sanitize/presets';
 
 export interface BlockHighlightTextProps extends DefaultComponentProps {
 	content: string;
@@ -65,6 +66,7 @@ export const BlockHighlightText: FunctionComponent<BlockHighlightTextProps> = ({
 						} as CSSProperties
 					}
 					content={content}
+					sanitizePreset={SanitizePreset.full}
 					type="p"
 				/>
 				<div className="c-block-highlight-text__pattern-slot c-block-highlight-text__pattern-slot--bottom">

--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHomepageBanner/BlockHomepageBanner.tsx
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHomepageBanner/BlockHomepageBanner.tsx
@@ -12,6 +12,7 @@ import {
 } from '~modules/content-page/types/content-block.types';
 import { ContentPageWidth } from '~modules/content-page/types/content-pages.types.ts';
 import Html from '~shared/components/Html/Html.tsx';
+import { SanitizePreset } from '~shared/helpers/sanitize/presets';
 
 export interface BlockHomepageBannerProps extends DefaultComponentProps {
 	title: string;
@@ -76,6 +77,7 @@ export const BlockHomepageBanner: FunctionComponent<BlockHomepageBannerProps> = 
 					<Html
 						className={clsx('c-block-homepage-banner__content-text', 'c-rich-text-editor__content')}
 						content={content}
+						sanitizePreset={SanitizePreset.full}
 						type="p"
 					/>
 					<div className="c-block-homepage-banner__pattern-slot c-block-homepage-banner__pattern-slot--bottom">

--- a/ui/src/react-admin/modules/shared/helpers/sanitize/presets/index.ts
+++ b/ui/src/react-admin/modules/shared/helpers/sanitize/presets/index.ts
@@ -38,7 +38,23 @@ export const link: DOMPurify.Config = {
 };
 
 export const full: DOMPurify.Config = {
-	ALLOWED_TAGS: [...(link.ALLOWED_TAGS || []), 'img', 'table', 'tr', 'td', 'div'],
+	ALLOWED_TAGS: [
+		...(link.ALLOWED_TAGS || []),
+		'img',
+		'div',
+		// A table needs its whole tag set. Without thead/tbody/th the browser keeps only the
+		// cell text and the table falls apart into a list of lines.
+		'table',
+		'caption',
+		'colgroup',
+		'col',
+		'thead',
+		'tbody',
+		'tfoot',
+		'tr',
+		'th',
+		'td',
+	],
 	RETURN_DOM: false,
 	ADD_ATTR: ['target'], // Allow target _blank for links
 };

--- a/ui/src/react-admin/modules/shared/helpers/sanitize/sanitize.test.ts
+++ b/ui/src/react-admin/modules/shared/helpers/sanitize/sanitize.test.ts
@@ -13,6 +13,13 @@ describe('sanitize', () => {
 		);
 	});
 
+	it('Should keep a whole table, header row included', () => {
+		const originalHtml =
+			'<table class="c-editor-table"><thead><tr><th>Kop</th></tr></thead><tbody><tr><td><p>cel</p></td></tr></tbody></table>';
+		const sanitizedHtml = sanitizeHtml(originalHtml, SanitizePreset.full);
+		expect(sanitizedHtml).toEqual(originalHtml);
+	});
+
 	it('Should remove link', () => {
 		const originalHtml =
 			'<p style="text-align:center">Simpel! Drie <a href="/start" target="_self">stappen</a> naar een geslaagde opdracht:</p>';


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3863

The sanitizer allow lists now name the whole table tag set, and both blocks sanitize with the full preset.