### PR TITLE
fix(tabs): fix z-index for tabs vs navigation dropdown

### DIFF
--- a/ui/src/react-admin/modules/shared/styles/generic/_global.scss
+++ b/ui/src/react-admin/modules/shared/styles/generic/_global.scss
@@ -28,3 +28,11 @@
   color: black;
   text-decoration: none;
 }
+
+// The active tab in the avo2-components Tabs sets a z-index (to lift its box-shadow above the
+// bottom border of the tab list). Since .c-tabs isn't a stacking context, that z-index leaks into
+// the root stacking context and makes the active tab render on top of the main site navigation
+// dropdown. Isolating .c-tabs keeps the tab z-index scoped to the tab list itself.
+.c-tabs {
+  isolation: isolate;
+}


### PR DESCRIPTION
before
<img width="1728" height="1084" alt="2026-08-21_15-35-48" src="https://github.com/user-attachments/assets/0e599b2d-e48e-46ae-81d6-3084a53fe776" />


after:
<img width="3456" height="1938" alt="image" src="https://github.com/user-attachments/assets/176d8c7b-0e19-4a11-8f84-9aacc014ab2d" />
