### PR TITLE
fix(block): make body text a textarea input for img text bg background

### DIFF
--- a/ui/src/react-admin/modules/content-page/components/blocks/BlockHetArchiefImageTextBackground/BlockHetArchiefImageTextBackground.editorconfig.ts
+++ b/ui/src/react-admin/modules/content-page/components/blocks/BlockHetArchiefImageTextBackground/BlockHetArchiefImageTextBackground.editorconfig.ts
@@ -15,12 +15,14 @@ import {
 import type { FileUploadProps } from '~modules/shared/components/FileUpload/FileUpload';
 import { GET_ADMIN_ICON_OPTIONS } from '~modules/shared/consts/icons.consts';
 import { tText } from '~shared/helpers/translation-functions';
-import type {
-	ContentBlockConfig,
-	DefaultContentBlockState,
-	HetArchiefImageTextBackgroundBlockComponentState,
+import {
+	Color,
+	type ContentBlockConfig,
+	ContentBlockEditor,
+	ContentBlockType,
+	type DefaultContentBlockState,
+	type HetArchiefImageTextBackgroundBlockComponentState,
 } from '../../../types/content-block.types';
-import { Color, ContentBlockEditor, ContentBlockType } from '../../../types/content-block.types';
 
 import {
 	BLOCK_FIELD_DEFAULTS,
@@ -95,6 +97,7 @@ export const HET_ARCHIEF_IMAGE_TEXT_BACKGROUND_BLOCK_CONFIG = (
 				},
 			},
 			content: TEXT_FIELD({
+				editorType: ContentBlockEditor.TextArea,
 				validator: undefined,
 			}),
 			textAlign: {


### PR DESCRIPTION
before:
<img width="3456" height="1938" alt="image" src="https://github.com/user-attachments/assets/ab37786d-b2c0-41fb-971e-c01fa9ee61d5" />


after:
<img width="1728" height="969" alt="2026-08-21_15-44-40" src="https://github.com/user-attachments/assets/e63f0c56-fdef-450e-9bf1-cae4e2d66c5f" />
